### PR TITLE
fix: Linux stabilization - gdextension lib paths, harness deletion bug, clippy

### DIFF
--- a/crates/compiler/src/suggestions.rs
+++ b/crates/compiler/src/suggestions.rs
@@ -39,8 +39,8 @@ pub fn levenshtein(a: &str, b: &str) -> usize {
     for (i, row) in matrix.iter_mut().enumerate().take(len_a + 1) {
         row[0] = i;
     }
-    for j in 0..=len_b {
-        matrix[0][j] = j;
+    for (j, cell) in matrix[0].iter_mut().enumerate() {
+        *cell = j;
     }
 
     // Fill matrix using dynamic programming

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1229,10 +1229,10 @@ fn assign_field(
                     },
                     Value::Rect2 { position, size } => match field {
                         "position" => {
-                            *position = Box::new(value);
+                            **position = value;
                         }
                         "size" => {
-                            *size = Box::new(value);
+                            **size = value;
                         }
                         _ => return Err(format!("Error[E702]: Rect2 has no field '{}'", field)),
                     },
@@ -1242,7 +1242,7 @@ fn assign_field(
                         scale,
                     } => match field {
                         "position" => {
-                            *position = Box::new(value);
+                            **position = value;
                         }
                         "rotation" => {
                             if let Some(f) = value.to_float() {
@@ -1255,7 +1255,7 @@ fn assign_field(
                             }
                         }
                         "scale" => {
-                            *scale = Box::new(value);
+                            **scale = value;
                         }
                         _ => {
                             return Err(format!(

--- a/crates/test_harness/src/test_runner.rs
+++ b/crates/test_harness/src/test_runner.rs
@@ -108,12 +108,22 @@ impl TestHarness {
         std::fs::create_dir_all(&scripts_dir)?;
         let dest_script = scripts_dir.join(script_name);
 
-        // Remove destination if it exists to avoid file lock issues
-        if dest_script.exists() {
-            let _ = std::fs::remove_file(&dest_script);
-        }
+        // When the scripts dir being tested IS the project scripts dir,
+        // source and destination are the same file — removing the
+        // "destination" would delete the source script itself.
+        let same_file = match (script_path.canonicalize(), dest_script.canonicalize()) {
+            (Ok(src), Ok(dst)) => src == dst,
+            _ => false,
+        };
 
-        std::fs::copy(script_path, &dest_script)?;
+        if !same_file {
+            // Remove destination if it exists to avoid file lock issues
+            if dest_script.exists() {
+                let _ = std::fs::remove_file(&dest_script);
+            }
+
+            std::fs::copy(script_path, &dest_script)?;
+        }
 
         // Build scene based on script requirements
         let script_res_path = format!("res://scripts/{}", script_name);

--- a/godot_test/ferrisscript.gdextension
+++ b/godot_test/ferrisscript.gdextension
@@ -4,11 +4,11 @@ compatibility_minimum = 4.1
 reloadable = true
 
 [libraries]
-linux.debug.x86_64 =     "res://../target/debug/ferrisscript_godot_bind.so"
-linux.release.x86_64 =   "res://../target/release/ferrisscript_godot_bind.so"
+linux.debug.x86_64 =     "res://../target/debug/libferrisscript_godot_bind.so"
+linux.release.x86_64 =   "res://../target/release/libferrisscript_godot_bind.so"
 windows.debug.x86_64 =   "res://../target/debug/ferrisscript_godot_bind.dll"
 windows.release.x86_64 = "res://../target/release/ferrisscript_godot_bind.dll"
-macos.debug =            "res://../target/debug/ferrisscript_godot_bind.dylib"
-macos.release =          "res://../target/release/ferrisscript_godot_bind.dylib"
-macos.debug.arm64 =      "res://../target/debug/ferrisscript_godot_bind.dylib"
-macos.release.arm64 =    "res://../target/release/ferrisscript_godot_bind.dylib"
+macos.debug =            "res://../target/debug/libferrisscript_godot_bind.dylib"
+macos.release =          "res://../target/release/libferrisscript_godot_bind.dylib"
+macos.debug.arm64 =      "res://../target/debug/libferrisscript_godot_bind.dylib"
+macos.release.arm64 =    "res://../target/release/libferrisscript_godot_bind.dylib"


### PR DESCRIPTION
## Summary

Fixes discovered while re-establishing a working baseline on Linux (first time this project has run on a non-Windows dev machine):

- **`.gdextension` library paths broken on Linux/macOS**: cargo produces lib-prefixed cdylibs (`libferrisscript_godot_bind.so`), but the paths lacked the prefix — the extension never loaded on non-Windows platforms, including CI-released artifacts.
- **Test harness deleted its own source scripts**: when the scripts dir under test is the project scripts dir (the default), the copy step removed the "destination" — which was the source file itself — destroying all 33 `.ferris` test scripts. Now skips copy when source == destination.
- **Clippy lints from newer stable**: `needless_range_loop` (suggestions.rs) and needless `Box::new` reallocations (runtime field assignment) fail the CI `-D warnings` gate on current stable.

## Test plan

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace` (883 passed) all green
- Extension verified loading and running under Godot 4.7.stable on Linux (headless)
- `ferris-test --all`: 19/33 pass; the 14 failures are pre-existing test-corpus drift (e.g. variadic `print`, unimplemented `match`), tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)