### PR TITLE
chore: fix stale docs, add Dependabot, tighten div-by-zero test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,10 +1,5 @@
 ## 🐛 Bug Fix
 
-<!-- 
-⚠️ IMPORTANT: This PR should target the 'develop' branch, not 'main'.
-Bug fixes go through develop for integration testing before reaching main.
--->
-
 <!-- Provide a clear and concise description of the bug you're fixing -->
 
 ## Related Issues

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,10 +1,5 @@
 ## 📝 Documentation Update
 
-<!-- 
-⚠️ IMPORTANT: This PR should target the 'develop' branch, not 'main'.
-Documentation updates go through develop for integration testing before reaching main.
--->
-
 <!-- Provide a clear description of what documentation you're adding or improving -->
 
 ## Related Issues

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,10 +1,5 @@
 ## ✨ New Feature
 
-<!-- 
-⚠️ IMPORTANT: This PR should target the 'develop' branch, not 'main'.
-Features go through develop for integration testing before reaching main.
--->
-
 <!-- Provide a clear and concise description of the new feature -->
 
 ## Related Issues

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Rust workspace (root Cargo.toml covers all crates/* members)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Docs/lint tooling at the repo root
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # VS Code extension
+  - package-ecosystem: "npm"
+    directory: "/extensions/vscode"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions workflow dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -2484,8 +2484,7 @@ mod tests {
 
     #[test]
     fn test_edge_case_division_by_zero() {
-        // Test division by zero behavior
-        // TODO: Should return an error instead of potentially undefined behavior
+        // Integer division by zero must return Error[E413], not panic.
         let mut env = Env::new();
         let source = r#"
             fn divide_by_zero() -> i32 {
@@ -2499,14 +2498,8 @@ mod tests {
         execute(&program, &mut env).unwrap();
 
         let result = call_function("divide_by_zero", &[], &mut env);
-        // Current behavior: division by zero may panic, error, or return undefined value
-        match result {
-            Ok(v) => println!(
-                "⚠️  Division by zero returned value (undefined behavior): {:?}",
-                v
-            ),
-            Err(e) => println!("✅ Division by zero produced error: {}", e),
-        }
+        assert!(result.is_err(), "division by zero should error, not panic");
+        assert!(result.unwrap_err().contains("E413"));
     }
 
     #[test]

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,12 +61,7 @@ FerrisScript provides comprehensive error documentation with:
 
 ### Planning & Roadmap
 
-Current development planning for v0.0.3:
-
-- [v0.0.3 Overview](planning/v0.0.3/README)
-- [Phase 1: Error Codes](planning/v0.0.3/PHASE_1_ERROR_CODES)
-- [Phase 2: Error Suggestions](planning/v0.0.3/PHASE_2_ERROR_SUGGESTIONS)
-- [Phase 3: Error Documentation](planning/v0.0.3/PHASE_3_ERROR_DOCS_RECOVERY)
+See the [Master Roadmap](https://github.com/dev-parkins/FerrisScript/blob/main/docs/planning/ROADMAP_MASTER.md) for current version status and what's planned next.
 
 ### Development Resources
 
@@ -79,20 +74,10 @@ Current development planning for v0.0.3:
 
 ## 🎯 Version Status
 
-**Current Version**: v0.0.2  
-**In Development**: v0.0.3 (Error System Enhancements)
+**Current Version**: v0.0.5 ("Stabilization & Engine Modernization")  
+**Godot**: 4.2+ (tested against 4.7) · **gdext**: 0.5.4 · **Rust**: 1.94+ (Edition 2024)
 
-### v0.0.3 Progress
-
-- ✅ **Phase 1**: Error Code System (E001-E499)
-- ✅ **Phase 2**: Error Suggestions ("Did you mean?")
-- ✅ **Phase 3A**: Documentation URLs in error messages
-- ✅ **Phase 3B**: Cross-references in ERROR_CODES.md
-- 🚧 **Phase 3C**: Parser error recovery (in progress)
-- ⏳ **Phase 3D**: Multi-error reporting
-- ⏳ **Phase 3E**: Integration and testing
-
-[View detailed roadmap →](planning/v0.0.3/README)
+[View detailed roadmap →](https://github.com/dev-parkins/FerrisScript/blob/main/docs/planning/ROADMAP_MASTER.md)
 
 ---
 

--- a/ferris-test.toml
+++ b/ferris-test.toml
@@ -1,7 +1,11 @@
 # FerrisScript Test Harness Configuration
 
-# Path to Godot console executable for headless testing
-godot_executable = "Y:\\cpark\\Projects\\Godot\\Godot_v4.5-dev4_win64.exe\\Godot_v4.5-dev4_win64_console.exe"
+# Path to Godot console executable for headless testing.
+# "godot" relies on it being on PATH (true after e.g. `pacman -S godot` on
+# Arch/CachyOS, or after adding the Godot install dir to PATH elsewhere).
+# Override per-machine with the GODOT_EXE env var instead of editing this
+# file, e.g.: GODOT_EXE=/path/to/godot cargo run -p ferrisscript_test_harness ...
+godot_executable = "godot"
 
 # Path to the Godot project directory
 project_path = "./godot_test"


### PR DESCRIPTION
## Summary

Findings from a roadmap/docs/tech-debt review pass done after the v0.0.5 release:

- Remove "target develop branch" instructions from all 3 PR templates (develop was deleted in PR #55; these were actively misdirecting contributors)
- Fix `docs/index.md` — the **published GitHub Pages homepage** — which showed "Current Version: v0.0.2" publicly, 3 releases stale
- Replace `ferris-test.toml`'s hardcoded personal Windows dev-build path with a portable `godot` (PATH-based) default plus `GODOT_EXE` override guidance
- Add `.github/dependabot.yml` for cargo, npm (root + vscode extension), and github-actions ecosystems
- Tighten `test_edge_case_division_by_zero` into a real regression assertion — the TODO/panic-risk framing was stale; division by zero already correctly returns `Error[E413]` rather than panicking, the test just never asserted on it

## Test plan

- `cargo test --workspace` green
- Manually reviewed the 3 PR template diffs and `docs/index.md` rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)