### PR TITLE
docs: resequence roadmap - language features before LSP

### DIFF
--- a/docs/planning/ROADMAP_MASTER.md
+++ b/docs/planning/ROADMAP_MASTER.md
@@ -2,7 +2,7 @@
 
 **Single Source of Truth for Version Planning**  
 **Last Updated**: July 21, 2026  
-**Current Version**: v0.0.5 in progress (Stabilization & Engine Modernization)
+**Current Version**: v0.0.5 shipped (Stabilization & Engine Modernization); v0.0.6 (language features) is next
 
 **Note (2026-07-21)**: The version originally planned as "v0.0.5: LSP
 Foundation and Safety Fix" has been renumbered to **v0.0.6** and every
@@ -26,19 +26,35 @@ Build a statically-typed, Rust-inspired scripting language for Godot with **comp
 
 ## 🎮 Positioning & Use Cases
 
+> **Note added 2026-07-21**: the differentiators and use cases below mix
+> **things that are true today** with **long-term aspiration**. A 2026-07-21
+> roadmap review found this table read as present-tense to a newcomer while
+> several claims (determinism, lockstep multiplayer, 1000+ agent simulations)
+> are explicitly marked "Aspirational"/"conditional on community validation"
+> in `VISION_USE_CASE_ANALYSIS.md` but that caveat doesn't survive into this
+> summary. Each item below is now marked ✅ **Today** or 🔮 **Aspirational**
+> — the aspirational ones have no fixed-point math, no `#[deterministic]`
+> annotation, no networking primitives, and no measured performance
+> benchmark against GDScript as of v0.0.5. Treat them as long-term direction,
+> not current capability.
+
 ### What FerrisScript Is
 
-> **"Rust-powered, statically compiled, Godot-native scripting for deterministic, high-performance gameplay systems"**
+> **"Rust-powered, statically compiled, Godot-native scripting for deterministic, high-performance gameplay systems"** 🔮 *(aspirational framing — see note above; today it's more accurately "a statically-typed, compile-time-checked scripting language for Godot")*
 
 **Key Differentiators vs GDScript**:
 
-1. **Compile-Time Safety**: Catch errors before running Godot
-2. **Deterministic Execution**: Perfect for lockstep multiplayer and replays
-3. **Predictable Performance**: Zero-cost abstractions, no GC pauses
-4. **Systems Integration**: Access Rust crates and native libraries
-5. **CI-Friendly**: Compile and test without launching the editor
+1. ✅ **Compile-Time Safety**: Catch errors before running Godot — true today
+2. 🔮 **Deterministic Execution**: Perfect for lockstep multiplayer and replays — aspirational, no determinism guarantees exist yet (Godot physics itself isn't deterministic either)
+3. ✅ **Predictable Performance**: Zero-cost abstractions, no GC pauses — true today (tree-walking interpreter, not yet benchmarked against GDScript)
+4. 🔮 **Systems Integration**: Access Rust crates and native libraries — not yet exposed to `.ferris` scripts
+5. ✅ **CI-Friendly**: Compile and test without launching the editor — true today
 
 ### Target Use Cases
+
+> 🔮 All rows below are aspirational positioning, not validated today — none
+> of these use cases has been built or benchmarked yet, and several require
+> language features (arrays, collections) that don't exist until v0.0.6+.
 
 | Use Case | Why FerrisScript | Example Games |
 |----------|------------------|---------------|
@@ -59,7 +75,41 @@ Build a statically-typed, Rust-inspired scripting language for Godot with **comp
 
 ---
 
-## 📍 Current State (v0.0.5 in progress, built on v0.0.4)
+## 🕳️ Known Gaps (Not Yet Planned)
+
+A 2026-07-21 roadmap review found several categories of work that don't appear
+*anywhere* in this roadmap, despite being real needs for a project at this
+stage. These are flagged, not solved — they need the maintainer's judgment,
+not a unilateral scoping decision:
+
+- **Community/adoption plan**: "community" appears elsewhere in this doc only
+  as a *gate* ("requires community validation before committing") — there is
+  no plan for how that validation signal would ever be generated. Zero known
+  external users today, no alpha/beta program, no outreach tied to any
+  milestone. `VISION_USE_CASE_ANALYSIS.md` floats "alpha/beta program for
+  simulation game developers" under "Missing Opportunities" but it was never
+  carried into this roadmap as a scoped deliverable.
+- **A "real playable game" checkpoint**: nothing explicitly targets "can a
+  solo dev ship a jam-sized game with FerrisScript." The closest proxy is a
+  "Demo Game Development" line item buried inside v0.1.0's 8-item feature
+  list — arguably the single most important validation the project needs,
+  undersold by its placement.
+- **Pre-1.0 compatibility/versioning policy**: nothing states what SemVer
+  means for this project pre-1.0 — whether `.ferris` scripts written against
+  v0.0.6 will still parse under v0.0.8, or what the breaking-change policy
+  is. For a language whose core pitch is compile-time reliability, having no
+  stated compatibility policy for its own version numbers is a gap worth
+  closing before v0.1.0.
+- **A recalibration trigger**: nothing says "after each version ships,
+  compare actual session count to the estimate and recalibrate the next
+  version's estimate by the same ratio." This is exactly why the LSP
+  estimate (`v0.0.7` now) survived two rounds of upward revision unchallenged
+  for 9 months — nobody had a standing reason to ask whether the unit
+  ("weeks") even made sense for how this project actually gets built.
+
+---
+
+## 📍 Current State (v0.0.5 complete, v0.0.6 next)
 
 ### What Works Today ✅
 
@@ -79,12 +129,12 @@ Build a statically-typed, Rust-inspired scripting language for Godot with **comp
 
 ### In Progress 🔄
 
-- 🔄 v0.0.5 "Stabilization & Engine Modernization" — see version details below
+- None — v0.0.5 shipped 2026-07-21; v0.0.6 (language features) is scoped but not started
 
 ### What's Missing ❌
 
-- ❌ LSP / editor support (coming in v0.0.6)
-- ❌ Arrays and for loops (coming in v0.0.7)
+- ❌ Arrays, for loops, match, string interpolation (coming in v0.0.6, next)
+- ❌ LSP / editor support (coming in v0.0.7)
 - ❌ Advanced Godot types (Vector3, Basis, etc. - coming in v0.0.8)
 - ❌ Metadata/manifest system (coming in v0.1.0)
 - ❌ Extended type system (i64, f64, u8, i16, u16 - coming in v0.2.0)
@@ -99,9 +149,9 @@ Build a statically-typed, Rust-inspired scripting language for Godot with **comp
 | Version | Status | Focus | Timeline | Premium Requests |
 |---------|--------|-------|----------|------------------|
 | **v0.0.4** | ✅ Complete | Godot API + Inspector integration | Completed Oct 10, 2025 | 6-8 used |
-| **v0.0.5** | 🔄 In Progress | Stabilization & Engine Modernization (gdext 0.5.4, Godot 4.7) | ~1 week | 4-6 |
-| **v0.0.6** | 📋 Next | LSP + Compiler Prerequisites + Test Framework 🛡️ | 6-7 weeks | 20-25 ⬆️ |
-| **v0.0.7** | 📋 Planned | Language features (arrays/for) | 2-3 weeks | 8-12 |
+| **v0.0.5** | ✅ Complete | Stabilization & Engine Modernization (gdext 0.5.4, Godot 4.7) | 1 session | ~4 used |
+| **v0.0.6** | 📋 Next | Language features: arrays, for-loops, match, string interpolation | 1-3 sessions (was "2-3 weeks") | 8-12 |
+| **v0.0.7** | 📋 Planned | LSP + Compiler Prerequisites + Test Framework 🛡️ | unknown — re-baseline after v0.0.6 ships (was "6-7 weeks") | 20-25 (unverified) |
 | **v0.0.8** | 📋 Planned | Godot API + node safety 🛡️ | 2-3 weeks | 9-12 ⬆️ |
 | **v0.1.0** | 🎯 Milestone | LSP UX + Type Safety + Metadata | 3-4 weeks | 10-15 ⬆️ |
 | **v0.2.0** | 🚀 Planned | Extended types + LSP Navigation + Validation | 4-5 weeks | 12-16 ⬆️ |
@@ -201,7 +251,7 @@ Build a statically-typed, Rust-inspired scripting language for Godot with **comp
 
 ---
 
-### v0.0.5: Stabilization & Engine Modernization (🔄 In Progress)
+### v0.0.5: Stabilization & Engine Modernization (✅ Complete, 2026-07-21)
 
 **Goal**: Return the project to a healthy, current baseline after 8 months of
 dormancy (last commit Oct 2025 → resumed July 2026) before continuing feature
@@ -281,11 +331,10 @@ effort on top of a stale foundation, this cycle stabilizes first.
 - [x] Renumbered `v0.0.5` (LSP Foundation) → `v0.0.6` and cascaded every
       later version up by one; moved `docs/planning/v0.0.5/` →
       `docs/planning/v0.0.6/`
-- [ ] Version bumps (workspace + all crates → 0.0.5), CHANGELOG/RELEASE_NOTES
-      finalization, tag `v0.0.5`
+- [x] Version bumps (workspace + all crates → 0.0.5), CHANGELOG/RELEASE_NOTES
+      finalization, tagged and released `v0.0.5`
 
-**Deliverables Remaining**: version bump finalization and release tag (see
-Phase 5 above).
+**Deliverables Remaining**: none — shipped.
 
 **What Was Delivered**: a current, healthy baseline — no code changes beyond
 dependency/API migration and bug fixes already merged in prior versions;
@@ -293,186 +342,11 @@ zero new language features (that resumes in `v0.0.7`, see below).
 
 ---
 
-### v0.0.6: LSP Foundation + Safety Fix (HIGHEST PRIORITY)
+### v0.0.6: Language Features (arrays, for-loops, match, string interpolation)
 
-**Goal**: Real-time diagnostics and node safety foundation
+**Goal**: Give FerrisScript the ability to express a real gameplay loop for the first time — arrays, iteration, and pattern matching.
 
-**Why This Matters**:
-
-- 🔥 **Editor Support**: Makes type safety visible while coding (red squiggles)
-- 🔥 **Differentiation**: Positions FerrisScript vs GDScript on developer experience
-- 🔥 **Adoption**: Attracts Rust developers who expect great tooling
-- 🛡️ **Safety**: Prevents crashes from freed nodes
-
-**Philosophy**: LSP transforms type safety from "annoying batch errors" to "helpful real-time guidance"
-
-**Phases** (Updated with Option A decisions):
-
-0. **Compiler Prerequisites** (3 PRs, 2-3 weeks) 🆕 BLOCKING
-   - **Phase 0.1**: Source spans in AST (1 week)
-     - Add `Span` and `Position` structs to all AST nodes
-     - Update parser to track spans from tokens
-     - Required for LSP error reporting
-   - **Phase 0.2**: Symbol table extraction (1 week)
-     - Extract symbol table from type checker
-     - Public API for LSP (go-to-definition, autocomplete)
-     - Scope chain tracking
-   - **Phase 0.3**: Incremental compilation (1 week)
-     - AST caching with source hash invalidation
-     - Dependency graph for transitive invalidation
-     - Target: 5-10x speedup for LSP responsiveness
-
-1. **Test Framework Foundation** (3-4 PRs, 1 week)
-   - Create `crates/test_harness` with metadata parsing
-   - Test discovery from `/examples` directory
-   - Rust test integration with filtering
-   - Cross-platform compatibility (Windows/Linux/macOS)
-
-2. **LSP Server Foundation** (2-3 PRs, 1 week)
-   - Create `ferrisscript_lsp` crate with tower-lsp
-   - Basic LSP protocol (initialize, shutdown, capabilities)
-   - Document manager with incremental compiler integration
-   - Text document synchronization (incremental updates)
-
-3. **LSP Test Integration** (2-3 PRs, 1 week)
-   - Custom LSP protocol (`ferrisscript/documentTests`, `ferrisscript/runTest`)
-   - Test discovery API in LSP
-   - Test result cache for status tracking
-   - VS Code CodeLens provider ("Run Test" buttons)
-
-4. **Real-Time Diagnostics** (2-3 PRs, 1 week)
-   - Integrate compiler with LSP (lexer → parser → type checker)
-   - Incremental compilation on each keystroke (using Phase 0.3 cache)
-   - Publish diagnostics (errors, warnings) to client
-   - Error recovery for partial syntax
-   - Performance target: <100ms for typical edits (cache hit)
-
-5. **Godot Test Runner** (2-3 PRs, 1 week)
-   - Implement `test_runner.gd` with assertion validation
-   - Timeout mechanism and signal monitoring
-   - JSON output for CI integration
-   - Cross-platform filesystem access
-
-6. **VS Code Extension** (2-3 PRs, 1 week)
-   - Extension scaffolding (package.json, activation)
-   - LSP client integration (vscode-languageclient)
-   - Enhanced syntax highlighting (TextMate grammar reuse)
-   - Marketplace publishing (extension ID, icon, README)
-
-**Deliverables**:
-
-- ✅ Compiler with source spans, symbol table, and incremental compilation
-- ✅ Consolidated test framework (single source of truth in `/examples`)
-- ✅ Working LSP server with real-time error checking
-- ✅ LSP test integration (CodeLens "Run Test" buttons)
-- ✅ VS Code extension published to marketplace
-- ✅ Red squiggles for type errors (instant feedback)
-- ✅ Godot headless test runner with assertion validation
-- ✅ CI integration with JSON test results
-- ✅ Documentation and installation guide
-
-**What's NOT Included** (deferred to v0.1.0):
-
-- ❌ Hover tooltips (needs Phase 0.2 symbol table, but UI deferred)
-- ❌ Autocomplete (needs Phase 0.2 symbol table, but UI deferred)
-- ❌ Go-to-definition (needs Phase 0.1 spans, but UI deferred)
-- ❌ Find references (needs Phase 0.2 symbol table, but UI deferred)
-- ❌ Node invalidation Phase 1 (moved to v0.0.8)
-
-**Timeline**: 6-7 weeks (was 3-4 weeks, then 4-5 weeks)  
-**Estimated Premium Requests**: 20-25 (was 11-16, then 13-18)
-
-**Timeline Breakdown**:
-
-- Weeks 1-3: Compiler prerequisites (spans, symbol table, incremental compilation)
-- Week 4: Test framework foundation
-- Week 5: LSP test integration
-- Week 6: Godot test runner
-- Week 7: CI integration and migration
-
-**Dependencies**: v0.0.4 complete
-
-**Note**: Focus on **diagnostics only** (Minimum Viable LSP). Additional features come in v0.1.0.
-
-**See**: `docs/planning/v0.0.6/LSP_ARCHITECTURE_SUPPORT.md` for detailed architecture
-
-#### v0.0.6 Consistency Checklist 🆕
-
-**Purpose**: Ensure all v0.0.6 planning documents align with master roadmap decisions.
-
-**Critical Decisions Made** (Option A for all):
-
-1. ✅ Ship v0.0.6 with compiler prerequisites (spans + symbol table) - adds 1 week
-2. ✅ Full LSP test integration in v0.0.6 - no deferral
-3. ✅ Add incremental compilation to v0.0.6 - adds 2-3 weeks
-
-**Updated Timeline**: 6-7 weeks (was 3-4 weeks, then 4-5 weeks)
-
-**Scope Consistency Checklist**:
-
-- [x] **CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md**:
-  - [x] Timeline updated to 6-7 weeks
-  - [x] Phase 0 added (Compiler Prerequisites: Spans, Symbol Table, Incremental Compilation)
-  - [x] Phase 2.5 includes test discovery API and result cache
-  - [x] Success criteria includes incremental compilation metrics
-  - [x] Dependencies section lists Phase 0 as blocking
-  - [x] Risk mitigation covers compiler refactoring and cache bugs
-
-- [x] **LSP_ARCHITECTURE_SUPPORT.md**: ✅ UPDATED
-  - [x] Verify incremental compilation architecture matches Phase 0.3
-  - [x] Confirm symbol table API matches Phase 0.2
-  - [x] Ensure span tracking matches Phase 0.1
-  - [x] Timeline reflects 6-7 weeks total (not just LSP-specific time)
-  - [x] Decision log documents Option A choices
-  - [x] Roadmap section updated with v0.0.6/v0.1.0 split
-
-- [ ] **ROADMAP_MASTER.md**: (This document)
-  - [x] v0.0.6 timeline updated to 6-7 weeks
-  - [x] Premium request estimate updated (13-18 → likely 20-25 with added scope)
-  - [ ] Phases 0-3 clearly documented
-  - [ ] Dependencies call out compiler prerequisites
-
-**Verification Steps**:
-
-1. **Before starting Phase 0**:
-   - [ ] All three documents agree on 6-7 week timeline
-   - [ ] Phase 0 tasks match across documents
-   - [ ] Compiler refactoring risks acknowledged
-
-2. **End of Week 3** (Decision Point):
-   - [ ] Phase 0 complete or on track
-   - [ ] Re-assess timeline if falling behind
-   - [ ] Consider de-scoping incremental compilation if critical
-
-3. **Before starting Phase 2.5** (Week 5):
-   - [ ] Compiler prerequisites (Phase 0) verified complete
-   - [ ] Symbol table API stable and tested
-   - [ ] Incremental compilation benchmarked
-
-**De-Scoping Plan** (if timeline slips):
-
-Priority 1 (Keep):
-
-- Source spans in AST
-- Symbol table extraction
-- Basic LSP diagnostics
-- Test framework foundation
-
-Priority 2 (Defer to v0.0.7 if needed):
-
-- Incremental compilation (fallback: always recompile)
-- LSP test integration (ship test framework standalone)
-
-Priority 3 (Defer to v0.1.0):
-
-- Advanced caching strategies
-- Dependency graph optimizations
-
----
-
-### v0.0.7: Language Features
-
-**Goal**: Arrays, loops, and pattern matching
+**Why this is next, ahead of LSP** (resequenced 2026-07-21, see "Roadmap Review" note below): FerrisScript cannot today express a collection of enemies, an inventory list, or a state machine — no arrays, no for-loops, no match. Every downstream goal (a real demo game, any external user trying the language, even LSP having something non-trivial to diagnose) depends on this landing first. It is also lower-risk than the LSP work it's swapping places with: additive language features rather than an AST-wide refactor touching 543+ existing compiler tests.
 
 **Features**:
 
@@ -500,15 +374,152 @@ Priority 3 (Defer to v0.1.0):
 
 - All language features implemented
 - Comprehensive tests
-- Examples for each feature
+- Examples for each feature (ideally exercising a real gameplay pattern — an enemy list, an inventory — not just syntax demonstrations)
 - Documentation updated
+- A short design doc (array mutation semantics, match exhaustiveness rules, reserved error-code range) written *before* implementation starts — this version had no scoping doc at all prior to the 2026-07-21 roadmap review; see `docs/planning/v0.0.6/README.md`
 
-**Timeline**: 2-3 weeks  
-**Estimated Premium Requests**: 8-12
+**Estimated effort**: 1-3 sessions (previously estimated "2-3 weeks / 8-12 premium requests" under the old human-sprint-cadence estimation model; re-baseline against actual pace once work starts — see the Roadmap Review note below)
 
-**Dependencies**: v0.0.6 Phase 2 (compiler integration)
+**Dependencies**: v0.0.5 complete
 
-**Parallelization**: Can start during v0.0.6 phases 3-5
+**See**: `docs/planning/v0.0.6/README.md` for the scoping doc
+
+---
+
+### v0.0.7: LSP Foundation + Test Framework 🛡️
+
+> **Moved here from v0.0.6 on 2026-07-21** (roadmap review, done alongside the v0.0.5 release). Originally slated as the top-priority "v0.0.5: LSP Alpha" back in October 2025 planning, then renumbered to v0.0.6 during the July 2026 return-from-dormancy stabilization pass — but never re-examined for whether it should still be *next*. It shouldn't be: LSP tooling (red squiggles, hover, autocomplete) has no audience yet (zero known external users), and its own risk register flags the compiler-prerequisites refactor (spans/symbol-table/incremental-compilation touching all 543+ compiler tests) as "Very High" risk — the riskiest work on the entire roadmap, in service of a feature nobody is asking for. Language features (now v0.0.6) unblock more value at lower risk. See `docs/planning/technical/` or session notes for the full reasoning if reconstructing this decision later.
+
+**Goal**: Real-time diagnostics and node safety foundation
+
+**Why This Matters**:
+
+- 🔥 **Editor Support**: Makes type safety visible while coding (red squiggles)
+- 🔥 **Differentiation**: Positions FerrisScript vs GDScript on developer experience
+- 🔥 **Adoption**: Attracts Rust developers who expect great tooling
+- 🛡️ **Safety**: Prevents crashes from freed nodes
+
+**Philosophy**: LSP transforms type safety from "annoying batch errors" to "helpful real-time guidance"
+
+**Phases** (Updated with Option A decisions):
+
+0. **Compiler Prerequisites** (3 PRs) 🆕 BLOCKING
+   - **Phase 0.1**: Source spans in AST — ✅ **already done**, shipped in v0.0.5 (`crates/compiler/src/span.rs`, PR #59). Note: byte offsets are still placeholder/zero (`TODO(v0.0.5)` in `parser.rs` — missed its own target release; needs finishing before LSP hover/precise-range features can use spans for real).
+   - **Phase 0.2**: Symbol table extraction
+     - Extract symbol table from type checker
+     - Public API for LSP (go-to-definition, autocomplete)
+     - Scope chain tracking
+   - **Phase 0.3**: Incremental compilation
+     - AST caching with source hash invalidation
+     - Dependency graph for transitive invalidation
+     - Target: 5-10x speedup for LSP responsiveness
+
+1. **Test Framework Foundation** (3-4 PRs)
+   - Create `crates/test_harness` with metadata parsing — ✅ **already done**, shipped in v0.0.4
+   - Test discovery from `/examples` directory
+   - Rust test integration with filtering
+   - Cross-platform compatibility (Windows/Linux/macOS)
+   - Consider shipping this piece standalone/early — it has value independent of spans/symbol-table/incremental-compilation and fixes a real present pain point (test duplication between `/examples` and `/godot_test/scripts`)
+
+2. **LSP Server Foundation** (2-3 PRs)
+   - Create `ferrisscript_lsp` crate with tower-lsp
+   - Basic LSP protocol (initialize, shutdown, capabilities)
+   - Document manager with incremental compiler integration
+   - Text document synchronization (incremental updates)
+
+3. **LSP Test Integration** (2-3 PRs)
+   - Custom LSP protocol (`ferrisscript/documentTests`, `ferrisscript/runTest`)
+   - Test discovery API in LSP
+   - Test result cache for status tracking
+   - VS Code CodeLens provider ("Run Test" buttons)
+
+4. **Real-Time Diagnostics** (2-3 PRs)
+   - Integrate compiler with LSP (lexer → parser → type checker)
+   - Incremental compilation on each keystroke (using Phase 0.3 cache)
+   - Publish diagnostics (errors, warnings) to client
+   - Error recovery for partial syntax
+   - Performance target: <100ms for typical edits (cache hit)
+
+5. **Godot Test Runner** (2-3 PRs)
+   - Implement `test_runner.gd` with assertion validation
+   - Timeout mechanism and signal monitoring
+   - JSON output for CI integration
+   - Cross-platform filesystem access
+
+6. **VS Code Extension** (2-3 PRs)
+   - Extension scaffolding (package.json, activation) — partially exists (`extensions/vscode/`, currently v0.0.3, syntax highlighting stale relative to current language surface — missing `@export`/`signal`/`struct`/`Color`/`Rect2`/`Transform2D`)
+   - LSP client integration (vscode-languageclient)
+   - Enhanced syntax highlighting (TextMate grammar reuse) — grammar refresh needed regardless of LSP timing, could be pulled forward as cheap standalone work
+   - Marketplace publishing (extension ID, icon, README) — no publish pipeline exists yet
+
+**Deliverables**:
+
+- ✅ Compiler with source spans (done, v0.0.5), symbol table, and incremental compilation
+- ✅ Consolidated test framework (single source of truth in `/examples`)
+- ✅ Working LSP server with real-time error checking
+- ✅ LSP test integration (CodeLens "Run Test" buttons)
+- ✅ VS Code extension published to marketplace
+- ✅ Red squiggles for type errors (instant feedback)
+- ✅ Godot headless test runner with assertion validation
+- ✅ CI integration with JSON test results
+- ✅ Documentation and installation guide
+
+**What's NOT Included** (deferred to v0.1.0):
+
+- ❌ Hover tooltips (needs Phase 0.2 symbol table, but UI deferred)
+- ❌ Autocomplete (needs Phase 0.2 symbol table, but UI deferred)
+- ❌ Go-to-definition (needs Phase 0.1 spans, but UI deferred)
+- ❌ Find references (needs Phase 0.2 symbol table, but UI deferred)
+- ❌ Node invalidation Phase 1 (moved to v0.0.8)
+
+**Estimated effort**: unknown — re-baseline against actual v0.0.6 (language features) pace before committing to a number. Historical estimate for reference only: "6-7 weeks / 20-25 premium requests," which had already doubled from an original 3-4 week estimate before a single line of code was written — treat that growth pattern as a signal the estimation method itself was unreliable, not as a floor.
+
+**Dependencies**: v0.0.6 (language features) complete
+
+**Note**: Focus on **diagnostics only** (Minimum Viable LSP). Additional features come in v0.1.0.
+
+**See**: `docs/planning/v0.0.7/LSP_ARCHITECTURE_SUPPORT.md` for detailed architecture (content unchanged from its original v0.0.6-slot version, just moved)
+
+#### v0.0.7 Consistency Checklist
+
+**Purpose**: Ensure all v0.0.7 planning documents align with master roadmap decisions.
+
+**Critical Decisions Made** (Option A for all, from original October 2025 planning):
+
+1. ✅ Ship with compiler prerequisites (spans + symbol table)
+2. ✅ Full LSP test integration — no deferral
+3. ✅ Add incremental compilation
+
+**Scope Consistency Checklist**:
+
+- [x] **CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md**: Phase 0 (Compiler Prerequisites), Phase 2.5 (test discovery API + result cache), risk mitigation for compiler refactoring — all documented, content unchanged from original v0.0.6 slot
+- [x] **LSP_ARCHITECTURE_SUPPORT.md**: incremental compilation architecture, symbol table API, span tracking, decision log — all documented, content unchanged from original v0.0.6 slot
+- [ ] **ROADMAP_MASTER.md**: (this document) — estimate re-baselined to "unknown, re-baseline after v0.0.6 ships" per the 2026-07-21 review; phases/dependencies updated to reflect the swap with language features
+
+**Verification Steps** (before resuming this work):
+
+1. Confirm v0.0.6 (language features) has actually shipped
+2. Re-baseline the effort estimate using v0.0.6's actual session count as a calibration point
+3. Finish the parser byte-offset TODO (spans are currently zero-length placeholders) before relying on spans for real diagnostics ranges
+4. Re-confirm compiler-refactoring risk is still acceptable given the codebase has grown since October 2025
+
+**De-Scoping Plan** (if it turns out larger than expected):
+
+Priority 1 (Keep):
+
+- Symbol table extraction
+- Basic LSP diagnostics
+- Test framework foundation (or ship this piece earlier, standalone)
+
+Priority 2 (Defer further, to v0.1.0 if needed):
+
+- Incremental compilation (fallback: always recompile)
+- LSP test integration (ship test framework standalone)
+
+Priority 3 (Defer to v0.1.0):
+
+- Advanced caching strategies
+- Dependency graph optimizations
 
 ---
 
@@ -670,43 +681,53 @@ Priority 3 (Defer to v0.1.0):
 
 - `docs/planning/v0.1.0-release-plan.md` for execution plan
 - `docs/TYPE_SAFETY_ROADMAP_ANALYSIS.md` for type safety details
-- `docs/planning/v0.0.6/LSP_ARCHITECTURE_SUPPORT.md` for LSP architecture
+- `docs/planning/v0.0.7/LSP_ARCHITECTURE_SUPPORT.md` for LSP architecture
 
 ---
 
 ## 🔀 Parallelization Strategy
 
-### Timeline Overview
+> **⚠️ Superseded 2026-07-21**: the timeline and "Editor Experience First"
+> priority below reflect the pre-resequencing plan (LSP as the very next
+> release, October 2025 planning). The 2026-07-21 roadmap review reversed
+> this — language features (now v0.0.6) ship before LSP (now v0.0.7) — see
+> the v0.0.6/v0.0.7 sections above for the reasoning. Kept below for
+> historical record; do not use the week numbers or "LSP first" framing to
+> plan actual work.
+
+### Timeline Overview (historical, pre-2026-07-21 plan)
 
 | Week | Primary Track | Secondary Track | Deliverable |
 |------|---------------|-----------------|-------------|
 | 1-2 | v0.0.4 Phase 2 | - | Lifecycle callbacks ✅ |
-| 3-6 | v0.0.6 Phases 1-2 | - | LSP foundation + diagnostics |
-| 7-9 | v0.0.6 Phases 3-4 | v0.0.7 arrays start | Autocomplete + navigation |
-| 10-11 | v0.0.6 Phase 5 | v0.0.7 for/match | VS Code extension published |
-| 12-14 | v0.0.8 Godot API | v0.0.7 string interp | API expansion complete |
+| 3-6 | LSP Phases 1-2 | - | LSP foundation + diagnostics |
+| 7-9 | LSP Phases 3-4 | Language features start | Autocomplete + navigation |
+| 10-11 | LSP Phase 5 | for/match | VS Code extension published |
+| 12-14 | Godot API expansion | string interp | API expansion complete |
 | 15-16 | v0.1.0 polish | - | v0.1.0 release 🎉 |
 
-**Key Insight**: Different crates can be developed simultaneously (LSP + language features)
+**Key Insight**: Different crates can be developed simultaneously (LSP + language features) — this parallelization opportunity is still real even with the reversed sequencing; language features (v0.0.6) and LSP prep work aren't mutually exclusive if capacity allows both.
 
 ---
 
 ## 🎯 Strategic Priorities
 
-### 1. Editor Experience First
+### 1. Editor Experience First — ⚠️ superseded, see banner above
 
-**Decision**: LSP in v0.0.6 (not v0.2.0 as originally planned)
+**Original decision (October 2025, no longer current)**: LSP in the very next release (not v0.2.0 as originally planned).
 
-**Rationale**:
+**Original rationale** (kept for context — this reasoning wasn't wrong, just outdated by the fact that the language couldn't express a loop yet):
 
 - Developers need great tooling to be productive
 - Editor support is adoption-critical
 - Differentiates FerrisScript from GDScript
 - Attracts Rust developers to Godot
 
+**Current decision (2026-07-21)**: language features ship first (v0.0.6); LSP follows (v0.0.7). See that section for why.
+
 ### 2. Smaller, Faster Releases
 
-**Decision**: Split v0.1.0 into v0.0.6-7 + v0.1.0 polish
+**Decision**: Split v0.1.0 into v0.0.6+v0.0.7 + v0.1.0 polish
 
 **Rationale**:
 
@@ -807,7 +828,7 @@ Priority 3 (Defer to v0.1.0):
 
 - `docs/planning/v0.2.0-roadmap.md` for type system details
 - `docs/TYPE_SAFETY_ROADMAP_ANALYSIS.md` for validation details
-- `docs/planning/v0.0.6/LSP_ARCHITECTURE_SUPPORT.md` for LSP navigation
+- `docs/planning/v0.0.7/LSP_ARCHITECTURE_SUPPORT.md` for LSP navigation
 
 ---
 
@@ -882,7 +903,7 @@ Priority 3 (Defer to v0.1.0):
 **See**:
 
 - `docs/planning/v0.3.0-roadmap.md` for arithmetic safety details
-- `docs/planning/v0.0.6/LSP_ARCHITECTURE_SUPPORT.md` for LSP advanced features
+- `docs/planning/v0.0.7/LSP_ARCHITECTURE_SUPPORT.md` for LSP advanced features
 - `docs/TYPE_SAFETY_ROADMAP_ANALYSIS.md` for type safety advanced (community validation required)
 
 ---
@@ -1071,6 +1092,15 @@ See `planning/VISION.md` for aspirational multi-year goals including:
 
 ## 📚 Related Documentation
 
+> **Note (2026-07-21)**: several filenames below (e.g. `v0.0.6-roadmap.md`,
+> `v0.0.7-7-roadmap.md`, `v0.1.0-ROADMAP.md`) don't exist in the current tree
+> — they were either never created or lost in the docs/archive incident
+> (PR #53/#54, partially recovered in v0.0.5). The version numbers in this
+> list also predate the 2026-07-21 language-features/LSP swap and haven't
+> been updated to match. Real, current planning docs live at
+> `docs/planning/v0.0.6/README.md` (language features) and
+> `docs/planning/v0.0.7/README.md` (LSP, moved from the v0.0.6 slot).
+
 ### Decision & Analysis Documents (Historical Context)
 
 - **planning/ROADMAP_CONSOLIDATION_ANALYSIS.md** - Strategic analysis (Oct 2025)
@@ -1150,26 +1180,28 @@ See `planning/VISION.md` for aspirational multi-year goals including:
 
 ## 🚀 Next Actions
 
-### This Week
+> The list below (from October 2025 planning) was entirely historical —
+> it described "this week" as executing v0.0.4 Phase 2, which shipped long
+> ago. Replaced 2026-07-21 with the actual current state.
 
-1. ✅ Complete roadmap consolidation analysis
-2. ✅ Review and approve strategic direction
-3. 🔄 Execute v0.0.4 Phase 2 (`_ready()` callback first)
-4. ⏳ Begin v0.0.6 LSP research
+### Now (as of 2026-07-21, v0.0.5 just shipped)
 
-### Next 2-4 Weeks
+1. ✅ v0.0.5 stabilization + gdext 0.5.4/Godot 4.7 upgrade shipped
+2. ✅ Roadmap resequenced: language features (v0.0.6) now precede LSP (v0.0.7)
+3. ✅ v0.0.6 scoping doc written (`docs/planning/v0.0.6/README.md`)
+4. ⏳ Begin v0.0.6 implementation (arrays first, per the suggested order in that doc)
 
-1. ⏳ Complete v0.0.4 Phase 2 (all lifecycle callbacks)
-2. ⏳ Ship v0.0.4 release
-3. ⏳ Start v0.0.6 LSP implementation
-4. ⏳ Archive superseded planning docs
+### Next 1-3 sessions
 
-### Next 2-3 Months
+1. ⏳ Ship v0.0.6 (arrays, for-loops, match, string interpolation)
+2. ⏳ Re-baseline v0.0.7's (LSP) effort estimate using v0.0.6's actual pace
+3. ⏳ Write a real example script per new language feature exercising a gameplay pattern, not just syntax
 
-1. ⏳ Complete v0.0.6 (LSP alpha)
-2. ⏳ Complete v0.0.7 (language features)
-3. ⏳ Complete v0.0.8 (Godot API)
-4. ⏳ Ship v0.1.0 milestone 🎉
+### Further out
+
+1. ⏳ v0.0.7: LSP foundation + test framework (re-scoped estimate)
+2. ⏳ v0.0.8: Godot API + node safety
+3. ⏳ v0.1.0 milestone — consider whether it should be split further; it currently bundles metadata/manifest system + demo game + doc site + performance validation into one release with no dedicated scoping doc yet
 
 ---
 

--- a/docs/planning/VISION.md
+++ b/docs/planning/VISION.md
@@ -40,12 +40,14 @@ This document outlines FerrisScript's aspirational future beyond v0.2.0. These a
 **Timeline**: 0-18 months  
 **Status**: ✅ Committed (see ROADMAP_MASTER.md)
 
-**Milestones**:
+**Milestones** (updated 2026-07-21 to match `ROADMAP_MASTER.md` — see that
+doc for why LSP moved behind language features):
 
-- v0.0.4: Runtime stability + lifecycle callbacks
-- v0.0.5: LSP Alpha for external editors
-- v0.0.6: Language features (arrays, for loops)
-- v0.0.7: Godot API expansion
+- v0.0.4: Runtime stability + lifecycle callbacks ✅ complete
+- v0.0.5: Stabilization & engine modernization (gdext 0.5.4, Godot 4.7) ✅ complete
+- v0.0.6: Language features (arrays, for loops, match, string interpolation)
+- v0.0.7: LSP Alpha for external editors
+- v0.0.8: Godot API expansion
 - v0.1.0: Manifest system + metadata
 - v0.2.0: Godot editor plugins + hot reload
 

--- a/docs/planning/VISION_USE_CASE_ANALYSIS.md
+++ b/docs/planning/VISION_USE_CASE_ANALYSIS.md
@@ -63,7 +63,7 @@ Five research documents explore FerrisScript's long-term potential across use ca
 
 ## 🔧 Developer Experience Features
 
-### v0.0.5-v0.1.0 (Immediate) ✅
+### v0.0.6-v0.1.0 (Immediate, updated 2026-07-21) ✅
 
 **Already Planned**:
 

--- a/docs/planning/v0.0.6/README.md
+++ b/docs/planning/v0.0.6/README.md
@@ -1,807 +1,131 @@
-# FerrisScript v0.0.6: LSP Foundation + Test Framework
+# FerrisScript v0.0.6: Language Features (Arrays, For-Loops, Match, String Interpolation)
 
-**Timeline**: 6-7 weeks  
-**Status**: Planning Complete  
-**Start Date**: TBD  
-**Target Completion**: TBD
+**Status**: Scoping (written 2026-07-21, no implementation started)
+**Timeline**: 1-3 sessions (see "On estimates" below — deliberately not given in calendar weeks)
 
 ---
 
-## 📋 Table of Contents
+## Why this exists
 
-- [Problem Statement](#-problem-statement)
-- [Solution Overview](#-solution-overview)
-- [Key Deliverables](#-key-deliverables)
-- [Acceptance Criteria](#-acceptance-criteria)
-- [Phase Breakdown](#-phase-breakdown)
-- [Work Delegation Strategy](#-work-delegation-strategy)
-- [Dependencies & Critical Path](#-dependencies--critical-path)
-- [Risk Management](#️-risk-management)
-- [Success Metrics](#-success-metrics)
+This is the first dedicated scoping doc for this version. Prior to 2026-07-21 it existed only as a four-bullet feature list inside `ROADMAP_MASTER.md`, with no syntax spec, no semantics decisions, and no reserved error-code range — in sharp contrast to the LSP plan (`docs/planning/v0.0.7/`, ~7,000 lines across 5 documents) that used to occupy this "next" slot. A 2026-07-21 roadmap review swapped the two: this version now ships first, because **FerrisScript currently cannot express a loop over a collection** — no arrays, no iteration, no pattern matching — which blocks every other goal (a real demo game, any external user trying the language, even giving LSP something non-trivial to diagnose later). See `ROADMAP_MASTER.md`'s v0.0.6 section for the full resequencing rationale.
 
----
+## Goal
 
-## 🎯 Problem Statement
+Give FerrisScript the minimum language surface needed to write a real, if simple, gameplay script — something with a list of enemies, an inventory, a state machine — end to end.
 
-### Current Pain Points
+## On estimates
 
-1. **No Real-Time Feedback**: Developers must compile manually to see type errors
-   - Write code → Save → Run `cargo build` → Read terminal output → Fix
-   - Feedback loop takes 30+ seconds per iteration
-   - Type safety feels like a burden, not a benefit
-
-2. **Fragmented Test Infrastructure**: Tests duplicated between `/examples` and `/godot_test/scripts`
-   - Manual test registration required
-   - No automated test discovery
-   - Platform-specific failures (Windows symlinks)
-   - CI doesn't catch all issues
-
-3. **Slow Compilation for LSP**: Full recompilation on every keystroke
-   - 150ms+ per edit is too slow for good editor experience
-   - No caching or incremental compilation
-   - LSP would feel sluggish and unresponsive
-
-4. **Missing LSP Foundation**: Compiler lacks infrastructure for editor integration
-   - No source span tracking (can't map errors to exact locations)
-   - No symbol table (can't implement go-to-definition)
-   - No incremental compilation (can't respond fast enough)
-
-### Impact on Adoption
-
-- **Developer Experience**: Static types without LSP = "annoying compile errors"
-- **Competitive Position**: GDScript has better IDE support despite dynamic typing
-- **Testing Friction**: Hard to add new tests, easy to break existing ones
-- **Iteration Speed**: Slow feedback loops discourage experimentation
+Do not estimate this in calendar weeks. The v0.0.7 (LSP) plan's "6-7 weeks" estimate was written in October 2025 under human-sprint-cadence assumptions and had already doubled from an original "3-4 weeks" before a single line of code was written — a signal the estimation *method* was unreliable, not just the number. Meanwhile the actual evidence from this project (v0.0.1→v0.0.4 shipped in 6 calendar days; the entire v0.0.5 stabilization + major gdext upgrade + release shipped in one AI-assisted session) shows multi-week-shaped work compressing into single-session work when this maintainer works with AI assistance. Track actual session count as you go and use it to calibrate v0.0.7's estimate afterward, rather than trusting either number in isolation.
 
 ---
 
-## 💡 Solution Overview
+## Current state (grounding this plan in the actual codebase, not assumptions)
 
-### What We're Building
-
-**v0.0.6 transforms FerrisScript from "compile-time safety" to "real-time developer experience"**
-
-#### Three Pillars
-
-1. **Compiler Prerequisites** (Weeks 1-3)
-   - Source spans: Map every AST node to exact source location
-   - Symbol table: Track all variables, functions, types across files
-   - Incremental compilation: Cache ASTs, recompile only changed regions
-   - **Goal**: Foundation for fast, accurate LSP
-
-2. **Test Framework Consolidation** (Weeks 4-7)
-   - Single source of truth: All tests in `/examples` with metadata
-   - Automated discovery: No manual registration
-   - LSP integration: Run tests from editor with "Run Test" button
-   - CI automation: JSON output for automated parsing
-   - **Goal**: Zero-friction testing for contributors
-
-3. **LSP Test Integration** (Week 5)
-   - Custom LSP protocol: `ferrisscript/documentTests`, `ferrisscript/runTest`
-   - CodeLens provider: Visual "Run Test" buttons in editor
-   - Real-time status: ✅/❌/⏱️ indicators
-   - Test result cache: Fast status updates
-   - **Goal**: Validate LSP infrastructure with low-risk scope
-
-### Why This Order?
-
-1. **Compiler first**: LSP needs spans, symbol table, incremental compilation
-2. **Test framework second**: Provides structured test cases for LSP validation
-3. **LSP test integration third**: Proves LSP works end-to-end before full diagnostics
-4. **General LSP later** (v0.1.0): Expand to all code once foundation is solid
+- `crates/compiler/src/type_checker.rs::Type` enum: `I32, F32, Bool, String, Vector2, Color, Rect2, Transform2D, Node, InputEvent, Void, Unknown`. No `Array`/`List` variant exists.
+- `crates/compiler/src/ast.rs::Stmt`: has `Let`, `Assign`, `If`, `While`, `Return`, `ExprStmt`, function/signal declarations. No `For`, no `Match`.
+- `crates/compiler/src/ast.rs::Expr`: literals, binary/unary ops, calls, field access, struct literals. No indexing (`arr[0]`), no array literal, no match expression, no string-interpolation literal.
+- Error codes currently run through **E815** (exports) with **E799/E800** as the highest reserved boundary before that range. Node-query errors are E601-E613, Godot-type errors are E701-E710. No range is reserved for arrays/loops/match/interpolation.
+- `docs/planning/v0.0.5/../archive` and `crates/runtime/src/lib.rs`/`type_checker.rs` already track a few open bugs relevant here: **`Stmt::Return` doesn't validate the return type against the function signature** (issue filed 2026-07-21) — worth fixing *before or alongside* this work, since match-as-expression and function returns interact, and a soundness hole here will make match/array bugs harder to diagnose.
 
 ---
 
-## 🎁 Key Deliverables
+## Feature 1: Arrays
 
-### Phase 0: Compiler Prerequisites (Weeks 1-3)
+### Syntax decisions
 
-| Deliverable | Description | Impact |
-|-------------|-------------|--------|
-| **Source Spans** | Every AST node tracks `(file, line, column, offset)` | LSP can show red squiggles at exact locations |
-| **Symbol Table** | Public API: `lookup(name) -> Symbol`, `all_symbols() -> Vec<Symbol>` | LSP can implement go-to-definition, autocomplete |
-| **Incremental Compiler** | `compile_file(uri, source)` with AST caching | <100ms compilation on typical edits |
-| **Dependency Graph** | Tracks which files import which, transitive invalidation | Cache invalidation works correctly |
+- **Type syntax**: `[T]` (e.g. `[i32]`, `[Vector2]`) — matches the original roadmap bullet and Rust-family conventions the language already leans on.
+- **Literals**: `[1, 2, 3]`. Empty array literal `[]` requires either a type annotation on the `let` (`let x: [i32] = [];`) or is a compile error without one (E9xx, "cannot infer type of empty array literal") — do not attempt bidirectional type inference for this version; require the annotation.
+- **Indexing**: `arr[0]`. Out-of-bounds access is a **runtime error** (new error code, not a panic — consistent with the existing division-by-zero E413 pattern), not a silently-wrapped/clamped value.
+- **Mutation semantics — the single most important open decision**: does `let mut arr: [i32] = [1,2,3]; arr.push(4);` mutate in place, or is `push` a method that returns a new array (functional style)? **Recommendation: in-place mutation, gated by `mut` the same way struct field mutation already works** (`let` = immutable/read-only, `let mut` = mutable — this pattern is already established for `@export` properties per `docs/ARCHITECTURE.md`). Functional/persistent arrays would be a bigger design commitment (immutable data structures, `arr.pushed(4)`-style non-mutating methods) that nothing else in the language currently does — don't introduce a novel mutation model just for arrays.
+- **Methods for v0.0.6**: `len()`, `push(item)`, `pop() -> Option<T>` (or a runtime error if empty — decide alongside whether the language has any `Option`-like type yet; if not, prefer an error over inventing `Option` as a side effect of this work). `get(i) -> T` (bounds-checked, same error as `[i]` indexing) is redundant with `[i]` — skip it unless there's a reason to distinguish "may fail" access.
+- **Explicitly out of scope for v0.0.6**: generic user-defined collection types, `HashMap`/dictionary types (the roadmap's `collections.ferris` placeholder conflates "arrays" with "collections" generally — this version is arrays only), slicing (`arr[1..3]`), array-of-arrays beyond what falls out naturally from `[T]` being recursively valid.
 
-### Phase 1: Test Framework (Week 4)
+### Error codes (proposed range: E900-E919)
 
-| Deliverable | Description | Impact |
-|-------------|-------------|--------|
-| **Test Harness Crate** | `crates/test_harness` with metadata parser | Discovers tests from `/examples` automatically |
-| **Rust Integration** | `tests/ferris_integration_tests.rs` | `cargo test` runs all FerrisScript tests |
-| **Test Filtering** | `FERRIS_TEST_FILTER=bounce cargo test` | Run specific tests during development |
-| **Cross-Platform** | Works on Windows/Linux/macOS | No more symlink failures |
-
-### Phase 2-2.5: LSP Foundation + Test Integration (Week 5)
-
-| Deliverable | Description | Impact |
-|-------------|-------------|--------|
-| **LSP Server** | `crates/lsp` with tower-lsp | Foundation for all LSP features |
-| **Document Manager** | Tracks open files, incremental updates | Handles `textDocument/didChange` efficiently |
-| **Custom Protocol** | `ferrisscript/documentTests`, `ferrisscript/runTest` | Editor can discover and run tests |
-| **CodeLens Provider** | VS Code extension shows "Run Test" buttons | Visual test execution from editor |
-
-### Phase 3-4: Godot Test Runner + Diagnostics (Week 6)
-
-| Deliverable | Description | Impact |
-|-------------|-------------|--------|
-| **Test Runner GDScript** | `godot_test/test_runner.gd` | Headless Godot test execution |
-| **Assertion Validation** | `get_variable()`, `get_emitted_signals()` | Tests actually validate behavior |
-| **Timeout Mechanism** | Configurable timeouts (default 10s) | Prevents hanging tests |
-| **Real-Time Diagnostics** | LSP publishes errors as you type | Red squiggles for type errors |
-
-### Phase 5: CI Integration (Week 7)
-
-| Deliverable | Description | Impact |
-|-------------|-------------|--------|
-| **GitHub Actions** | Updated workflow with new test harness | Automated testing on every PR |
-| **JSON Output** | `test_runner.gd --json` mode | CI can parse results |
-| **Test Migration** | All tests moved to `/examples` | Single source of truth |
+- E900: Array literal type mismatch (mixed element types)
+- E901: Cannot infer type of empty array literal (no annotation)
+- E902: Array index out of bounds (runtime)
+- E903: Cannot index into non-array type
+- E904: Array method called on non-array type
 
 ---
 
-## ✅ Acceptance Criteria
+## Feature 2: For loops
 
-### Must Have (Blocking Release)
+### Syntax decisions
 
-- [ ] **All AST nodes have source spans**
-  - Parser tracks spans from tokens
-  - All tests updated with span assertions
-  - Error messages show exact locations
+- **For-in**: `for item in array { ... }` — iterates by value (consistent with the language's existing "clone, don't reference-count" evaluation model per `docs/ARCHITECTURE.md`'s known limitations).
+- **Range**: `for i in 0..10 { ... }` (exclusive end, matching Rust). Whether to also support inclusive `0..=10` is a nice-to-have, not required for v0.0.6 — cut it if time-constrained, the language is not trying to be a complete Rust clone.
+- **Break/continue**: standard, no labeled loops (`'outer: for ...`) — the language has no `while`-loop labels today either, don't introduce label syntax for the first loop construct that needs it.
+- **Scoping**: the loop variable (`item`, `i`) is scoped to the loop body only, immutable by default within the body unless the language's existing `mut` rules are extended to loop variables (recommend: loop variables follow the same immutable-by-default rule as `let`, since mutating the iteration variable of a `for-in` doesn't affect the underlying array anyway given by-value iteration above).
 
-- [ ] **Symbol table built during type checking**
-  - `SymbolTable` API: `lookup()`, `all_symbols()`, `symbols_in_scope()`
-  - Integration tests verify symbol resolution
-  - Public API documented
+### Error codes (proposed range: E920-E939)
 
-- [ ] **Incremental compilation working**
-  - Cache hit rate >80% for typical edits
-  - <100ms latency for cache hits
-  - 5-10x speedup vs full recompilation
-
-- [ ] **Test framework consolidated**
-  - Zero `.ferris` files in `/godot_test/scripts`
-  - All tests in `/examples` with metadata
-  - `cargo test` discovers and runs all tests
-
-- [ ] **LSP test integration working**
-  - CodeLens shows "Run Test" button
-  - Clicking runs test and shows result (✅/❌)
-  - Test status persists in cache
-
-- [ ] **Cross-platform compatibility**
-  - Tests pass on Windows, Linux, macOS
-  - No platform-specific workarounds
-  - CI validates all platforms
-
-### Should Have (Nice to Have)
-
-- [ ] **Performance optimizations**
-  - Cache eviction policy (LRU)
-  - Disk cache for persistence
-  - Metrics dashboard
-
-- [ ] **Enhanced test metadata**
-  - Regex patterns for assertions
-  - Multiple timeout values
-  - Test categories/tags
-
-- [ ] **Better error messages**
-  - Span-based error highlighting
-  - Suggested fixes
-  - Error code links to docs
-
-### Won't Have (Deferred to v0.1.0)
-
-- ❌ **Hover tooltips** (needs Phase 0.2, but UI deferred)
-- ❌ **Autocomplete** (needs Phase 0.2, but UI deferred)
-- ❌ **Go-to-definition** (needs Phase 0.1, but UI deferred)
-- ❌ **Find references** (needs Phase 0.2, but UI deferred)
+- E920: `for-in` target is not iterable (not an array or range)
+- E921: `break`/`continue` used outside a loop
 
 ---
 
-## 📦 Phase Breakdown
+## Feature 3: Match expressions
 
-### Phase 0: Compiler Prerequisites (Weeks 1-3) 🔴 CRITICAL PATH
+### Syntax decisions
 
-**Why First**: LSP fundamentally requires these features. Cannot proceed without them.
+- **Match as expression** (not just statement) — `let x = match y { ... };` — per the original roadmap bullet. This is more work than statement-only match but is consistent with `if` already being usable as an expression-like construct in the language (verify this against the current parser before committing — if `if` is statement-only today, match should probably also start statement-only and become an expression in a later version, rather than match leapfrogging if in expressiveness).
+- **Patterns for v0.0.6**: literal patterns (`match x { 1 => ..., 2 => ..., _ => ... }`) and the wildcard `_`. **Explicitly defer enum/struct pattern destructuring** — the language has no user-defined enums yet (only built-in struct types like `Color`/`Rect2`), so there's nothing to destructure beyond literals. Don't build pattern-matching infrastructure for a type system feature (enums) that doesn't exist yet.
+- **Exhaustiveness checking**: required for literal-int/bool matches where the domain is enumerable in a useful way is impractical (i32 has 2^32 values) — in practice this means **exhaustiveness checking reduces to "does this match have a `_` wildcard arm or a `bool` match covering both `true`/`false`."** Don't try to build general exhaustiveness analysis (e.g. detecting `match x { 1 => .., 2 => .. }` on an i32 as "non-exhaustive" is trivially true and not useful to flag beyond "you're missing a `_` arm").
 
-#### Week 1: Source Spans + Inspector Fix
+### Error codes (proposed range: E940-E959)
 
-**Goal**: Every AST node knows where it came from in the source code + fix Inspector property refresh bug
-
-**Tasks**:
-
-1. Define `Span` and `Position` structs (`crates/compiler/src/span.rs`)
-2. Add `span` field to all AST nodes (`crates/compiler/src/ast.rs`)
-3. Update parser to track spans from tokens
-4. Update all tests with span assertions (543 compiler tests)
-5. **🆕 Fix Inspector property refresh on compilation errors** (Quick win, 1-2 hours)
-
-**Acceptance Criteria**:
-
-- [x] `Span::new(start, end)` and `Span::merge(other)` work
-- [x] Every `Expr`, `Stmt`, `Type` has a `span()` method
-- [x] Parser creates spans from token positions
-- [x] Error messages include `Span` information
-- [x] All 568 compiler tests pass with spans (31 new span unit tests + 5 integration tests)
-- [x] **🆕 Inspector clears properties on compilation failure** (PR #60, shipped in v0.0.5)
-- [x] **🆕 Switching scripts after type error updates Inspector correctly** (PR #60, verified headlessly in v0.0.5 — see `INSPECTOR_PROPERTY_FIX.md`)
-
-**Complexity**: 🔴 HIGH (touches entire AST, all tests)  
-**Delegation**: ❌ **User-Interactive** (requires careful review of each AST node)
-
-**Quick Win**: Inspector fix can run in parallel as background agent task  
-**📄 Inspector Fix Details**: See [INSPECTOR_PROPERTY_FIX.md](INSPECTOR_PROPERTY_FIX.md)
-
-**✅ Completed (PR #TBD)**: Tasks 1-4 complete. Created `span.rs` module with Position/Span structs, updated AST/parser/type_checker, all tests passing.
-
-**⚠️ Implementation Notes**:
-
-- **Byte offset tracking**: Currently using placeholder `0` values. Lexer doesn't track byte positions yet. Deferred to future enhancement (can calculate from line/column if needed, but adds overhead).
-- **Point spans**: Most spans are zero-length (start == end) because `span_from()` helper exists but isn't called yet. Multi-token span tracking deferred to Week 2 parser enhancements.
-- **Backward compatibility**: Re-exported `Span` from `ast` module to avoid breaking runtime crate. All existing `ast::Span` references still work.
+- E940: Non-exhaustive match (missing `_` wildcard, or missing a `bool` arm)
+- E941: Unreachable match arm (duplicate literal pattern)
+- E942: Match arms have inconsistent types (when used as an expression)
 
 ---
 
-#### Week 2: Symbol Table
+## Feature 4: String interpolation
 
-**Goal**: Extract symbol information for LSP (variables, functions, types)
+### Syntax decisions
 
-**Tasks**:
+- **Syntax**: `"Hello {name}"` per the original roadmap bullet (Rust itself uses this exact syntax as of `format!("Hello {name}")` shorthand — consistent with the language's Rust-inspired positioning).
+- **Expression support**: `"{x + 1}"` (arbitrary expressions inside braces) vs. identifier-only (`"{x}"`, no expressions). **Recommendation: identifiers only for v0.0.6**, matching the "String Interpolation (1-2 PRs)" small sizing already in the roadmap — full expression support inside string literals is a lexer/parser interaction (re-entering expression parsing mid-string-token) that's disproportionate scope for what's meant to be the smallest of the four features here. Expand to full expressions in a later version if identifier-only proves limiting in practice.
+- **Escaping**: literal `{` / `}` via `{{` / `}}`, matching Rust's `format!` convention (keeps this consistent with the "Rust-inspired" pitch and avoids inventing a new escaping convention).
 
-1. Define `SymbolTable`, `Symbol`, `Scope` structs (`crates/compiler/src/symbol_table.rs`)
-2. Refactor `TypeChecker` to build `SymbolTable` during type checking
-3. Update `compile()` to return `(Type, SymbolTable)`
-4. Add integration tests for symbol resolution
+### Error codes (proposed range: E960-E969)
 
-**Acceptance Criteria**:
-
-- [ ] `SymbolTable::lookup(name)` returns `Option<&Symbol>`
-- [ ] `SymbolTable::all_symbols()` returns all symbols
-- [ ] `SymbolTable::symbols_in_scope(id)` walks scope chain
-- [ ] `TypeChecker` inserts symbols for variables, functions, parameters
-- [ ] Integration tests verify symbol table correctness
-
-**Complexity**: 🟡 MEDIUM (refactoring existing type checker)  
-**Delegation**: ⚠️ **User-Guided** (needs review of type checker logic)
+- E960: Undefined variable inside string interpolation
+- E961: Unmatched `{` in string literal (missing `}` or invalid escape)
 
 ---
 
-#### Week 3: Incremental Compilation
+## Suggested implementation order
 
-**Goal**: Cache ASTs and recompile only changed regions
+1. **Arrays** first — everything else (for-in, and eventually match on array contents) depends on there being something to iterate over. Also the most self-contained: new `Type::Array(Box<Type>)` variant, new `Expr::ArrayLiteral`/`Expr::Index`, new methods.
+2. **For loops** second — directly depends on arrays existing (for-in) plus ranges (independent of arrays, could be done in either order, but pairing them keeps "iteration" as one coherent unit of work).
+3. **Match expressions** third — independent of arrays/loops, could run in parallel if splitting work, but sequencing after them keeps error-code ranges and testing patterns consistent with what's just been established.
+4. **String interpolation** last — smallest, most isolated (lexer-level change), least likely to interact with the other three.
 
-**Tasks**:
+Each feature should land as its own PR (or small PR sequence) with its own tests, mirroring the pattern already used for v0.0.4's phases (signals, lifecycle callbacks, node queries, etc. each shipped as separable PRs) rather than one large PR bundling all four.
 
-1. Implement `IncrementalCompiler` with AST caching (`crates/compiler/src/incremental.rs`)
-2. Add source hash-based cache invalidation
-3. Create `DependencyGraph` for transitive invalidation
-4. Performance benchmarks (cache hit rate, latency)
+## Test plan
 
-**Acceptance Criteria**:
+- Unit tests in `crates/compiler/src/*.rs` for lexer/parser/type-checker coverage of each feature (matching the existing pattern — the compiler crate currently has 543+ tests structured this way).
+- Runtime tests in `crates/runtime/src/lib.rs` for evaluation semantics (array mutation, loop execution, match dispatch, interpolation formatting).
+- **At least one `godot_test/scripts/*.ferris` example per feature that exercises a real gameplay pattern** (an enemy list iterated with `for`, a simple state machine via `match`, a score/health display via string interpolation) — not just a syntax-demonstration script. This directly addresses a gap the July 2026 roadmap review flagged: current examples don't demonstrate real usage because the language couldn't express real usage yet.
+- Ensure new `ferris-test` corpus scripts use the harness's structured `// ASSERT:` metadata format (literal substring matching), not free-form prose — a July 2026 tech-debt review found most of the current corpus's "failures" were exactly this mistake, not real bugs.
 
-- [ ] `IncrementalCompiler::compile_file(uri, source)` uses cache
-- [ ] Cache hit returns result in <50ms (target: <100ms acceptable)
-- [ ] Cache miss does full compilation and caches result
-- [ ] `DependencyGraph` invalidates dependent files
-- [ ] Benchmarks show 5-10x speedup for cache hits
-- [ ] Cache hit rate >80% for typical editing sessions
+## Explicitly out of scope for v0.0.6
 
-**Complexity**: 🟡 MEDIUM (new module, integration with compiler)  
-**Delegation**: ✅ **Background Agent** (well-defined spec, testable in isolation)
+- Generics of any kind (arrays are `[T]` for a fixed concrete `T`, not `Array<T>` with user-provided type parameters beyond the one being iterated)
+- Dictionaries/maps/hashmaps (tracked separately, likely v0.2.0+ per the "Extended Types" version)
+- User-defined enums (match's pattern vocabulary stays literal-only until these exist)
+- Full expression interpolation (`"{x + 1}"`) — identifiers only this round
+- Slicing, array concatenation, sorting, or other higher-order array methods beyond `len`/`push`/`pop`
 
----
+## Dependencies
 
-### Phase 1: Test Framework Foundation (Week 4)
+v0.0.5 complete (shipped 2026-07-21).
 
-**Why Now**: Provides test infrastructure for validating LSP integration
+## See also
 
-#### Tasks
-
-1. **Create Test Harness Crate** (2 days)
-   - `crates/test_harness/Cargo.toml`
-   - Metadata parser: `parse_test_metadata(source) -> TestMetadata`
-   - Test discovery: `discover_tests(examples_dir) -> Vec<TestFile>`
-   - Error handling with `thiserror`
-
-2. **Rust Test Integration** (2 days)
-   - `tests/ferris_integration_tests.rs`
-   - Test filtering: `FERRIS_TEST_FILTER=bounce cargo test`
-   - Parallel execution with `rayon`
-   - Negative testing support
-
-3. **Cross-Platform Validation** (1 day)
-   - Test on Windows (absolute paths, no symlinks)
-   - Test on Linux (standard paths)
-   - Test on macOS (if available)
-
-**Acceptance Criteria**:
-
-- [ ] `cargo test` discovers all `.ferris` files in `/examples`
-- [ ] Metadata parsing handles all fields: `TEST:`, `CATEGORY:`, `EXPECT:`, `ASSERT:`, `TIMEOUT:`
-- [ ] Test filtering works: `FERRIS_TEST_FILTER=bounce cargo test` runs only bounce test
-- [ ] Cross-platform: Tests pass on Windows, Linux, macOS
-- [ ] All tests have clear error messages for malformed metadata
-
-**Complexity**: 🟢 LOW (new crate, clear spec)  
-**Delegation**: ✅ **Background Agent** (unambiguous requirements, well-tested)
-
----
-
-### Phase 2: LSP Server Foundation (Week 5a - Days 1-3)
-
-**Why Now**: Needs Phase 0 (compiler prerequisites) complete
-
-#### Tasks
-
-1. **Create LSP Crate** (1 day)
-   - `crates/lsp/Cargo.toml` with `tower-lsp` dependency
-   - Basic server struct: `FerrisScriptServer`
-   - Initialize/shutdown handlers
-
-2. **Document Manager** (1 day)
-   - Track open documents: `HashMap<Url, Document>`
-   - Apply incremental changes: `did_change` handler
-   - Integrate with `IncrementalCompiler` from Phase 0.3
-
-3. **Text Synchronization** (1 day)
-   - Handle `textDocument/didOpen`
-   - Handle `textDocument/didChange` (incremental)
-   - Handle `textDocument/didClose`
-
-**Acceptance Criteria**:
-
-- [ ] LSP server starts and responds to `initialize` request
-- [ ] Document manager tracks open files
-- [ ] Incremental changes apply correctly (no corruption)
-- [ ] `IncrementalCompiler` recompiles on each change
-- [ ] Server handles multiple documents simultaneously
-
-**Complexity**: 🟡 MEDIUM (new LSP infrastructure)  
-**Delegation**: ⚠️ **User-Guided** (LSP protocol requires careful implementation)
-
----
-
-### Phase 2.5: LSP Test Integration (Week 5b - Days 4-5)
-
-**Why Now**: Validates LSP works before full diagnostics (lower risk)
-
-#### Tasks
-
-1. **Custom LSP Protocol** (1 day)
-   - Define `ferrisscript/documentTests` request/response
-   - Define `ferrisscript/runTest` request/response
-   - Implement handlers in LSP server
-
-2. **Test Discovery API** (1 day)
-   - Use `test_harness` crate from Phase 1
-   - Parse test metadata from open documents
-   - Return test ranges (line numbers)
-
-3. **VS Code Extension** (1 day)
-   - `testProvider.ts` with CodeLens provider
-   - "Run Test" command
-   - Test result UI (✅/❌/⏱️)
-
-**Acceptance Criteria**:
-
-- [ ] Opening `.ferris` file shows "Run Test" button above test
-- [ ] Clicking button runs test via LSP
-- [ ] Test result appears in editor (✅ pass, ❌ fail)
-- [ ] Test status persists in cache (doesn't re-run on every edit)
-- [ ] Multiple tests in same file all work
-
-**Complexity**: 🟡 MEDIUM (custom LSP protocol, VS Code extension)  
-**Delegation**: ⚠️ **User-Guided** (integration between LSP server and VS Code)
-
----
-
-### Phase 3: Real-Time Diagnostics (Week 6a - Days 1-3)
-
-**Why Now**: Validates incremental compilation works with LSP
-
-#### Tasks
-
-1. **Diagnostic Publishing** (1 day)
-   - Convert compile errors to LSP `Diagnostic` format
-   - Use `Span` from Phase 0.1 for accurate ranges
-   - Publish on every `textDocument/didChange`
-
-2. **Error Recovery** (1 day)
-   - Parser continues on errors (don't stop at first error)
-   - Type checker handles incomplete ASTs
-   - Show partial diagnostics even with syntax errors
-
-3. **Performance Validation** (1 day)
-   - Benchmark latency: target <100ms for typical edits
-   - Verify cache hit rate >80%
-   - Profile slow paths
-
-**Acceptance Criteria**:
-
-- [ ] Red squiggles appear as you type (not just on save)
-- [ ] Error messages accurate to exact location (uses spans)
-- [ ] Latency <100ms for cache hits (typical single-line edit)
-- [ ] Multiple errors shown simultaneously
-- [ ] Parser doesn't crash on incomplete code
-
-**Complexity**: 🟡 MEDIUM (error recovery is tricky)  
-**Delegation**: ⚠️ **User-Guided** (performance tuning requires iteration)
-
----
-
-### Phase 4: Godot Test Runner (Week 6b - Days 4-5)
-
-**Why Now**: Can run in parallel with Phase 3 (different codebase)
-
-#### Tasks
-
-1. **Test Runner Script** (1 day)
-   - `godot_test/test_runner.gd`
-   - Discover tests via `FileAccess.open()` (no symlinks)
-   - Load and run FerrisScript via `FerrisScriptRunner`
-   - JSON output mode
-
-2. **Assertion Validation** (1 day)
-   - Add `get_variable(name)` to `FerrisScriptRunner`
-   - Add `get_emitted_signals()` to `FerrisScriptRunner`
-   - Parse `ASSERT:` metadata and validate
-   - Timeout mechanism (default 10s)
-
-**Acceptance Criteria**:
-
-- [ ] `godot --headless --script test_runner.gd` runs all tests
-- [ ] Tests timeout after 10s (configurable via `TIMEOUT:` metadata)
-- [ ] Assertions validate actual runtime behavior (not just "compiles")
-- [ ] JSON output parses correctly in CI
-- [ ] Works on Windows (no symlink issues)
-
-**Complexity**: 🟢 LOW (GDScript, clear spec)  
-**Delegation**: ✅ **Background Agent** (well-defined, testable in Godot)
-
----
-
-### Phase 5: CI Integration & Migration (Week 7)
-
-**Why Now**: Final integration, migration, polish
-
-#### Tasks
-
-1. **GitHub Actions Workflow** (1 day)
-   - Update `.github/workflows/test.yml`
-   - Run `cargo test` (Phase 1 harness)
-   - Run `godot --headless` (Phase 4 runner)
-   - Parse JSON results
-
-2. **Test Migration** (2 days)
-   - Move all `.ferris` files from `/godot_test/scripts` to `/examples`
-   - Add metadata to each test
-   - Update documentation
-
-3. **Cleanup** (1 day)
-   - Remove old test infrastructure
-   - Update README
-   - Create migration guide for contributors
-
-4. **Final Validation** (1 day)
-   - Run full test suite on CI
-   - Verify all platforms pass
-   - Check performance metrics
-
-**Acceptance Criteria**:
-
-- [ ] CI runs on every PR and passes
-- [ ] No `.ferris` files remain in `/godot_test/scripts`
-- [ ] All tests have metadata headers
-- [ ] Documentation updated (README, CONTRIBUTING)
-- [ ] Migration guide written
-
-**Complexity**: 🟢 LOW (mostly migration, documentation)  
-**Delegation**: ✅ **Background Agent** (bulk file operations, well-defined)
-
----
-
-## 🤖 Work Delegation Strategy
-
-### Background Agent Tasks (Can Run Unattended)
-
-These tasks have:
-
-- ✅ Clear, unambiguous requirements
-- ✅ Well-defined acceptance criteria
-- ✅ No complex design decisions
-- ✅ Easy to verify automatically (tests)
-
-| Phase | Task | Rationale |
-|-------|------|-----------|
-| **0.3** | Incremental Compilation | Well-specified caching logic, testable in isolation |
-| **1** | Test Harness Crate | New crate, clear spec, comprehensive tests |
-| **4** | Godot Test Runner | GDScript implementation, clear inputs/outputs |
-| **5** | Test Migration | Bulk file operations, metadata addition |
-| **5** | CI Integration | GitHub Actions YAML, JSON parsing |
-
-**Estimated Background Work**: ~2-3 weeks of the 6-7 week timeline
-
----
-
-### User-Guided Tasks (Need Iteration & Feedback)
-
-These tasks have:
-
-- ⚠️ Complex design decisions
-- ⚠️ Integration with existing code
-- ⚠️ Performance tuning required
-- ⚠️ Multiple valid approaches
-
-| Phase | Task | Why User-Guided |
-|-------|------|-----------------|
-| **0.1** | Source Spans in AST | Touches 543 tests, every AST node, needs careful review |
-| **0.2** | Symbol Table Extraction | Refactors type checker, complex scope handling |
-| **2** | LSP Server Foundation | LSP protocol requires careful implementation |
-| **2.5** | LSP Test Integration | Custom protocol, VS Code extension integration |
-| **3** | Real-Time Diagnostics | Error recovery is tricky, performance tuning |
-
-**Estimated User-Guided Work**: ~3-4 weeks of the 6-7 week timeline
-
----
-
-### Parallelization Opportunities
-
-| Primary Track | Secondary Track (Background Agent) | Week |
-|---------------|-----------------------------------|------|
-| Phase 0.1: Source Spans | - | 1 |
-| Phase 0.2: Symbol Table | - | 2 |
-| Phase 0.3: Incremental Compilation ⚠️ | Can be background if spec clear | 3 |
-| Phase 1: Test Harness (user review) | Phase 1: Tests/docs (agent writes) | 4 |
-| Phase 2: LSP Server (user guided) | Phase 4: Godot Runner (agent writes) | 5 |
-| Phase 2.5 + 3: LSP Test Integration | - | 6 |
-| Phase 5: Final validation | Phase 5: Migration (agent executes) | 7 |
-
-**Key Insight**: Weeks 4-6 have the most parallelization potential. User works on LSP while agent handles Godot test runner.
-
----
-
-## 🔗 Dependencies & Critical Path
-
-### Critical Path (Must Complete in Order)
-
-```
-Phase 0.1 (Spans) 
-    ↓
-Phase 0.2 (Symbol Table) 
-    ↓
-Phase 0.3 (Incremental Compilation)
-    ↓
-Phase 2 (LSP Server Foundation)
-    ↓
-Phase 2.5 (LSP Test Integration)
-    ↓
-Phase 3 (Real-Time Diagnostics)
-```
-
-**Timeline**: 6 weeks (Weeks 1-6)
-
-**Blocker**: Cannot start Phase 2 until Phase 0 complete (needs spans, symbol table, incremental compiler)
-
----
-
-### Parallel Paths (Can Run Simultaneously)
-
-```
-Phase 1 (Test Harness) ─┐
-                        ├─→ Phase 2.5 (LSP Test Integration)
-Phase 4 (Godot Runner) ─┘
-
-Phase 5 (CI Integration) ← All above complete
-```
-
-**Optimization**:
-
-- Phase 1 (Week 4) can run while finishing Phase 0 if Phase 0 is ahead of schedule
-- Phase 4 (Week 6) can run in parallel with Phase 3 (different codebase)
-- Phase 5 (Week 7) waits for everything
-
----
-
-## ⚠️ Risk Management
-
-### High-Risk Items (Require Mitigation)
-
-#### Risk 1: Compiler Refactoring Breaks Tests 🔴 HIGH
-
-**Probability**: Very High  
-**Impact**: All 543 compiler tests may fail after adding spans
-
-**Mitigation**:
-
-- Add spans incrementally (one AST node type at a time)
-- Use default/dummy spans for unmodified nodes during transition
-- Run full test suite after each AST change
-- Create migration script to bulk-update test assertions
-- **Timeline Buffer**: 1 week contingency built into Phase 0
-
-**Decision Point**: End of Week 1 - if span migration is slower than expected, consider temporary dummy spans
-
----
-
-#### Risk 2: Incremental Compilation Cache Bugs 🔴 HIGH
-
-**Probability**: Medium  
-**Impact**: LSP shows stale errors, incorrect completions
-
-**Mitigation**:
-
-- Extensive unit tests for cache invalidation (test each scenario)
-- Add cache validation mode (compare cached vs fresh compilation)
-- Implement "force full recompilation" command in LSP
-- Monitor cache hit rate in production
-- **Fallback**: Disable caching if bugs persist (graceful degradation)
-
-**Decision Point**: End of Week 3 - verify cache correctness before proceeding to LSP
-
----
-
-#### Risk 3: Timeline Overrun (7 weeks → 9+ weeks) 🟡 MEDIUM
-
-**Probability**: Medium  
-**Impact**: Delayed v0.0.6 release
-
-**Mitigation**:
-
-- Phase 0 has highest risk (3 weeks of compiler changes)
-- Weekly check-ins to assess timeline
-- De-scope features if falling behind (see Priority Plan below)
-- **Decision Point**: End of Week 3 (reassess after Phase 0)
-
-**De-Scoping Priority**:
-
-**Priority 1 (Must Keep)**:
-
-- Source spans in AST
-- Symbol table extraction
-- Basic LSP diagnostics
-- Test framework foundation
-
-**Priority 2 (Defer to v0.0.6 if behind)**:
-
-- Incremental compilation (fallback: always recompile)
-- LSP test integration (ship test framework standalone)
-
-**Priority 3 (Defer to v0.1.0)**:
-
-- Advanced caching strategies
-- Dependency graph optimizations
-
----
-
-### Medium-Risk Items (Monitor Closely)
-
-#### Risk 4: LSP Protocol Complexity 🟡 MEDIUM
-
-**Mitigation**: Start with simple test-specific LSP (Phase 2.5) before full diagnostics
-
-#### Risk 5: Cross-Platform Test Failures 🟡 MEDIUM
-
-**Mitigation**: Test on all platforms early (Phase 1, Week 4)
-
-#### Risk 6: Performance Regression 🟡 MEDIUM
-
-**Mitigation**: Benchmark cache hit rate, establish performance baselines
-
----
-
-## 📊 Success Metrics
-
-### Performance Metrics
-
-| Metric | Target | Acceptable | Measurement |
-|--------|--------|------------|-------------|
-| **Cache Hit Rate** | >95% | >80% | Track in `IncrementalCompiler::metrics()` |
-| **Cache Hit Latency** | <50ms | <100ms | Benchmark on typical edits |
-| **Cache Miss Latency** | <200ms | <500ms | Full recompilation time |
-| **Speedup vs Full Recompile** | 10x | 5x | Compare cache hit vs miss |
-| **LSP Response Time** | <100ms | <200ms | `textDocument/didChange` → diagnostics published |
-
----
-
-### Quality Metrics
-
-| Metric | Target | Measurement |
-|--------|--------|-------------|
-| **Test Coverage** | >80% | Lines covered by `cargo test` |
-| **Cross-Platform** | 100% pass | Tests pass on Windows, Linux, macOS |
-| **Zero Regressions** | 0 | All 843 existing tests still pass |
-| **Documentation** | 100% | All public APIs documented |
-
----
-
-### Adoption Metrics (Post-Release)
-
-| Metric | Target | Measurement |
-|--------|--------|-------------|
-| **LSP Usage** | >50% of contributors | VS Code extension installs |
-| **Test Additions** | +10% tests in 2 weeks | Track new `.ferris` files in `/examples` |
-| **Issue Reports** | <5 critical bugs | GitHub issues labeled `v0.0.6` |
-| **Feedback Sentiment** | >80% positive | Survey or Discord reactions |
-
----
-
-## 📚 Related Documents
-
-- **[CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md](./CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md)**: Detailed implementation guide with code examples
-- **[LSP_ARCHITECTURE_SUPPORT.md](./LSP_ARCHITECTURE_SUPPORT.md)**: LSP architecture, rationale, and incremental compilation details
-- **[ROADMAP_MASTER.md](../ROADMAP_MASTER.md)**: High-level version roadmap and consistency checklist
-
----
-
-## 🚀 Getting Started
-
-### For Contributors
-
-1. **Read this README** to understand the big picture
-2. **Review Phase 0** (Compiler Prerequisites) - this is the critical path
-3. **Check [CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md](./CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md)** for detailed implementation
-4. **Start with Phase 0.1** (Source Spans) - Week 1
-
-### For Project Leads
-
-1. **Review delegation strategy** (Background Agent vs User-Guided)
-2. **Set up weekly check-ins** (especially end of Week 3 decision point)
-3. **Monitor risk items** (compiler refactoring, cache bugs, timeline)
-4. **Prepare de-scoping plan** if timeline slips
-
-### For Background Agents
-
-**Week 3-4**: Incremental Compilation (Phase 0.3) + Test Harness (Phase 1)  
-**Week 5-6**: Godot Test Runner (Phase 4)  
-**Week 7**: Test Migration + CI Integration (Phase 5)
-
----
-
-## 🔗 Related Documents
-
-### Planning Documents
-
-- **[CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md](CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md)**: Detailed technical implementation guide with code examples
-- **[LSP_ARCHITECTURE_SUPPORT.md](LSP_ARCHITECTURE_SUPPORT.md)**: LSP architecture, incremental compilation design, decision log
-- **[ROADMAP_MASTER.md](../ROADMAP_MASTER.md)**: High-level version roadmap and consistency checklist
-
-### Task Documents
-
-- **[INSPECTOR_PROPERTY_FIX.md](INSPECTOR_PROPERTY_FIX.md)**: 🆕 Quick win bug fix (Phase 0.1.5) - Inspector property refresh on compilation error
-
-### Reference Documents
-
-- **[TROUBLESHOOTING.md](../../TROUBLESHOOTING.md)**: Known issues and workarounds
-- **[DEVELOPMENT.md](../../DEVELOPMENT.md)**: Development workflow and contribution guide
-- **[ARCHITECTURE.md](../../ARCHITECTURE.md)**: System architecture overview
-
----
-
-## ✅ Current Status
-
-- [x] **Planning Complete** (October 13, 2025)
-  - [x] Option A decisions documented
-  - [x] All three documents aligned (CONSOLIDATED, LSP, ROADMAP)
-  - [x] README.md created with phase breakdown
-  - [x] Delegation strategy defined
-  - [x] Inspector fix task document created (INSPECTOR_PROPERTY_FIX.md)
-
-- [ ] **Phase 0.1: Source Spans** (Week 1)
-  - [ ] Define `Span` and `Position` structs
-  - [ ] Add spans to all AST nodes
-  - [ ] Update parser to track spans
-  - [ ] Update all 543 compiler tests
-
-- [ ] **Phase 0.2: Symbol Table** (Week 2)
-- [ ] **Phase 0.3: Incremental Compilation** (Week 3)
-- [ ] **Phase 1: Test Framework** (Week 4)
-- [ ] **Phase 2-2.5: LSP Foundation + Test Integration** (Week 5)
-- [ ] **Phase 3-4: Diagnostics + Godot Runner** (Week 6)
-- [ ] **Phase 5: CI Integration & Migration** (Week 7)
-
----
-
-**Last Updated**: October 13, 2025  
-**Next Review**: End of Week 3 (Decision Point)
+- `ROADMAP_MASTER.md` — version summary, resequencing rationale
+- `docs/planning/v0.0.7/` — the LSP plan this version displaced; its compiler-prerequisites work (spans, symbol table) is independent of this version and not a blocker

--- a/docs/planning/v0.0.7/CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md
+++ b/docs/planning/v0.0.7/CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md
@@ -4,7 +4,7 @@
 **Status**: Planning (Updated with LSP Integration)  
 **Date**: October 13, 2025  
 **Priority**: High  
-**Dependencies**: Test harness crate, GDExtension runtime, LSP server (v0.0.6)  
+**Dependencies**: Test harness crate, GDExtension runtime, LSP server (v0.0.7)  
 
 ## Executive Summary
 
@@ -18,7 +18,7 @@ This document has been **updated to include critical gaps** identified in the fe
    - Code lens test status indicators (✅/❌/▶️)
    - "Run Test" command from editor
    - Real-time test result updates
-   - **Impact**: Essential for v0.0.6 editor experience
+   - **Impact**: Essential for v0.0.7 editor experience
    - **Timeline Impact**: +1-2 weeks
 
 2. **Test Assertions Validation** 🟡 IMPORTANT
@@ -1185,7 +1185,7 @@ fn extract_error_code(error_msg: &str) -> String {
 
 ### Phase 2.5: LSP Test Integration (2-3 days) 🆕
 
-**Critical for v0.0.6**: LSP needs to integrate with test framework for editor features.
+**Critical for v0.0.7**: LSP needs to integrate with test framework for editor features.
 
 #### 2.5.1 LSP Protocol Extensions
 
@@ -2657,16 +2657,16 @@ For more information, see:
 ### Soft Dependencies (Nice to Have)
 
 1. **Test Coverage Tooling**
-   - Not required for v0.0.6
-   - Can defer to v0.0.6
+   - Not required for v0.0.7
+   - Can defer to v0.0.7
 
 2. **Test Profiling/Benchmarking**
    - Nice for identifying slow tests
-   - Not blocking v0.0.6 release
+   - Not blocking v0.0.7 release
 
 2. **Performance Benchmarking**
-   - Not required for v0.0.6
-   - Can defer to v0.0.6
+   - Not required for v0.0.7
+   - Can defer to v0.0.7
 
 ### Integration Points with LSP
 
@@ -2708,13 +2708,13 @@ Test Execution   Test Status Cache
 - **Fallback**: Disable caching if bugs persist (graceful degradation)
 
 ### Risk 3: LSP Integration Complexity 🔴 HIGH
-**Impact**: Could delay entire v0.0.6 release  
+**Impact**: Could delay entire v0.0.7 release  
 **Probability**: Medium  
 **Mitigation**: 
 - Complete Phase 0 (compiler prerequisites) FIRST (Weeks 1-3)
 - Define protocol extensions early (Week 5, Day 1)
 - Create mock LSP server for Phase 2.5 testing
-- Have fallback: Ship test framework without LSP, add in v0.0.6
+- Have fallback: Ship test framework without LSP, add in v0.0.7
 - **Timeline Buffer**: LSP work starts Week 5 (after compiler ready)
 
 ### Risk 4: Godot FileAccess Limitations ✅ MITIGATED
@@ -2731,7 +2731,7 @@ Test Execution   Test Status Cache
 **Mitigation**: 
 - Start with simple string matching
 - Phase 2: Add regex patterns
-- Phase 3: Full DSL parser (can defer to v0.0.6)
+- Phase 3: Full DSL parser (can defer to v0.0.7)
 
 ### Risk 7: Performance Regression from Incremental Compilation Overhead 🟡 MEDIUM 🆕
 **Impact**: LSP slower than expected despite caching  
@@ -2743,7 +2743,7 @@ Test Execution   Test Status Cache
 - **Target**: <100ms for typical edits (cache hit)
 
 ### Risk 8: Timeline Overrun (7 weeks → 9+ weeks) 🟡 MEDIUM 🆕
-**Impact**: Delayed v0.0.6 release  
+**Impact**: Delayed v0.0.7 release  
 **Probability**: Medium  
 **Mitigation**:
 - Phase 0 has highest risk (3 weeks of compiler changes)
@@ -3074,7 +3074,7 @@ RUST_LOG=debug cargo test -- --nocapture
 
 ---
 
-**Ready for Implementation**: This plan is production-ready and addresses all issues identified in the feedback phase, including LSP integration requirements for v0.0.6.
+**Ready for Implementation**: This plan is production-ready and addresses all issues identified in the feedback phase, including LSP integration requirements for v0.0.7.
 
 **Next Steps**:
 
@@ -3087,5 +3087,5 @@ RUST_LOG=debug cargo test -- --nocapture
 **Critical Dependencies**:
 
 - LSP server foundation must be ready before Phase 2.5
-- If LSP is delayed, ship test framework without editor integration in v0.0.6
-- Add LSP integration in v0.0.6 as enhancement
+- If LSP is delayed, ship test framework without editor integration in v0.0.7
+- Add LSP integration in v0.0.7 as enhancement

--- a/docs/planning/v0.0.7/INSPECTOR_PROPERTY_FIX.md
+++ b/docs/planning/v0.0.7/INSPECTOR_PROPERTY_FIX.md
@@ -352,7 +352,7 @@ mod tests {
 
 ## 🔗 Related Documents
 
-- **Planning**: [v0.0.6 README.md](README.md) (this fix is Phase 0.1.5)
+- **Planning**: [v0.0.7 README.md](README.md) (this fix is Phase 0.1.5)
 - **Issue**: [TROUBLESHOOTING.md](../../TROUBLESHOOTING.md#inspector-properties-not-updating)
 - **Implementation**: `crates/godot_bind/src/lib.rs`
 
@@ -367,7 +367,7 @@ This is a **quick win** that can run in parallel with Phase 0.1 (Source Spans). 
 - Clear root cause
 - Simple 2-line fix
 - Well-defined test procedure
-- No dependencies on other v0.0.6 work
+- No dependencies on other v0.0.7 work
 
 ### Agent Execution Steps
 

--- a/docs/planning/v0.0.7/LSP_ARCHITECTURE_SUPPORT.md
+++ b/docs/planning/v0.0.7/LSP_ARCHITECTURE_SUPPORT.md
@@ -1,6 +1,6 @@
 Excellent question! LSP is **the missing piece** that transforms FerrisScript from "static types for safety" to "static types for **developer experience**". Let me break down how LSP amplifies your type safety philosophy.
 
-## 📝 Decision Log (v0.0.6 Planning)
+## 📝 Decision Log (v0.0.7 Planning)
 
 **Date**: October 13, 2025
 
@@ -12,8 +12,8 @@ Excellent question! LSP is **the missing piece** that transforms FerrisScript fr
 
 **Options**:
 
-- **A**: Ship v0.0.6 with compiler prerequisites (+1 week)
-- B: Defer to v0.1.0 (ship test framework in v0.0.6, add compiler later)
+- **A**: Ship v0.0.7 with compiler prerequisites (+1 week)
+- B: Defer to v0.1.0 (ship test framework in v0.0.7, add compiler later)
 
 **Chosen**: **Option A**
 
@@ -28,7 +28,7 @@ Excellent question! LSP is **the missing piece** that transforms FerrisScript fr
 
 #### Decision 2: LSP Test Integration Scope
 
-**Question**: How much LSP integration in v0.0.6?
+**Question**: How much LSP integration in v0.0.7?
 
 **Options**:
 
@@ -52,7 +52,7 @@ Excellent question! LSP is **the missing piece** that transforms FerrisScript fr
 
 **Options**:
 
-- **A**: Add incremental compilation to v0.0.6 (+2-3 weeks)
+- **A**: Add incremental compilation to v0.0.7 (+2-3 weeks)
 - B: Defer to v0.1.0+ (ship without caching, add later)
 
 **Chosen**: **Option A**
@@ -94,7 +94,7 @@ Excellent question! LSP is **the missing piece** that transforms FerrisScript fr
 - Basic LSP diagnostics
 - Test framework foundation
 
-**Priority 2 (Defer to v0.0.6 if behind schedule)**:
+**Priority 2 (Defer to v0.0.7 if behind schedule)**:
 
 - Incremental compilation (fallback: always recompile)
 - LSP test integration (ship test framework standalone)
@@ -428,7 +428,7 @@ async fn publish_diagnostics(&self, uri: &Url) {
 
 ## 🎯 LSP Features Priority for FerrisScript
 
-### Phase 0: Test-Specific LSP (v0.0.6) 🆕 UPDATED
+### Phase 0: Test-Specific LSP (v0.0.7) 🆕 UPDATED
 
 **Goal**: LSP integration for test framework
 
@@ -440,9 +440,9 @@ async fn publish_diagnostics(&self, uri: &Url) {
 - ✅ Test result caching
 - ✅ Real-time test status updates
 
-**Implementation**: ~1-2 weeks (Week 5 of v0.0.6)
+**Implementation**: ~1-2 weeks (Week 5 of v0.0.7)
 
-**Scope**: LSP features are **test-specific only** in v0.0.6. General LSP features (diagnostics for all code, autocomplete, etc.) come in v0.1.0.
+**Scope**: LSP features are **test-specific only** in v0.0.7. General LSP features (diagnostics for all code, autocomplete, etc.) come in v0.1.0.
 
 **Why Test-Specific First?**:
 
@@ -466,9 +466,9 @@ async fn publish_diagnostics(&self, uri: &Url) {
 
 **Implementation**: ~2 weeks
 
-**Dependencies**: Requires v0.0.6 compiler prerequisites (spans, symbol table, incremental compilation)
+**Dependencies**: Requires v0.0.7 compiler prerequisites (spans, symbol table, incremental compilation)
 
-**Note**: This expands the test-specific diagnostics from v0.0.6 to all FerrisScript code.
+**Note**: This expands the test-specific diagnostics from v0.0.7 to all FerrisScript code.
 
 ---
 
@@ -484,7 +484,7 @@ async fn publish_diagnostics(&self, uri: &Url) {
 
 **Implementation**: ~2 weeks
 
-**Dependencies**: v0.0.6 Phase 0.1 (spans) and Phase 0.2 (symbol table)
+**Dependencies**: v0.0.7 Phase 0.1 (spans) and Phase 0.2 (symbol table)
 
 ---
 
@@ -516,7 +516,7 @@ async fn publish_diagnostics(&self, uri: &Url) {
 
 **Implementation**: ~2 weeks
 
-**Dependencies**: v0.1.1 (navigation), v0.0.6 Phase 0.2 (symbol table)
+**Dependencies**: v0.1.1 (navigation), v0.0.7 Phase 0.2 (symbol table)
 
 ---
 
@@ -531,7 +531,7 @@ async fn publish_diagnostics(&self, uri: &Url) {
 
 **Dependencies**: v0.1.3 (full IntelliSense)
 
-## � Incremental Compilation Architecture (v0.0.6 Phase 0.3)
+## � Incremental Compilation Architecture (v0.0.7 Phase 0.3)
 
 ### Why Incremental Compilation is Critical for LSP
 
@@ -987,7 +987,7 @@ fn move_player(direction: Vector2) {
 
 ## 📋 Recommended Roadmap
 
-### v0.0.6 (Current Release) - UPDATED
+### v0.0.7 (Current Release) - UPDATED
 
 **Focus**: LSP Foundation + Test Framework + Incremental Compilation
 
@@ -995,9 +995,9 @@ fn move_player(direction: Vector2) {
 
 **Critical Decisions** (Option A for all):
 
-1. ✅ Ship v0.0.6 with compiler prerequisites (spans + symbol table) - adds 1 week
-2. ✅ Full LSP test integration in v0.0.6 - no deferral
-3. ✅ Add incremental compilation to v0.0.6 - adds 2-3 weeks
+1. ✅ Ship v0.0.7 with compiler prerequisites (spans + symbol table) - adds 1 week
+2. ✅ Full LSP test integration in v0.0.7 - no deferral
+3. ✅ Add incremental compilation to v0.0.7 - adds 2-3 weeks
 
 #### Phase 0: Compiler Prerequisites (Weeks 1-3) 🆕 BLOCKING
 
@@ -1077,9 +1077,9 @@ fn move_player(direction: Vector2) {
 
 **Decision Rationale**:
 
-- Chose Option A: Ship v0.0.6 with full compiler prerequisites
+- Chose Option A: Ship v0.0.7 with full compiler prerequisites
 - Chose Option A: Full LSP test integration (not deferred)
-- Chose Option A: Incremental compilation in v0.0.6 (not v0.1.0+)
+- Chose Option A: Incremental compilation in v0.0.7 (not v0.1.0+)
 
 ---
 
@@ -1096,9 +1096,9 @@ fn move_player(direction: Vector2) {
 - [ ] Document symbols (outline view, Ctrl+Shift+O)
 - [ ] Basic autocomplete (context-aware completions)
 
-**Note**: v0.0.6 already includes LSP test integration + compiler prerequisites, so v0.1.0 expands LSP to general coding features.
+**Note**: v0.0.7 already includes LSP test integration + compiler prerequisites, so v0.1.0 expands LSP to general coding features.
 
-**Dependencies**: v0.0.6 compiler prerequisites (spans, symbol table, incremental compilation)
+**Dependencies**: v0.0.7 compiler prerequisites (spans, symbol table, incremental compilation)
 
 ---
 
@@ -1140,7 +1140,7 @@ fn move_player(direction: Vector2) {
 
 ---
 
-## 📊 v0.0.6 Implementation Summary
+## 📊 v0.0.7 Implementation Summary
 
 **Timeline**: 6-7 weeks (was 2-3 weeks)
 
@@ -1150,7 +1150,7 @@ fn move_player(direction: Vector2) {
 - ✅ Test framework with LSP integration - Weeks 4-5
 - ✅ Godot test runner and CI - Weeks 6-7
 
-**v0.0.6 Delivers**:
+**v0.0.7 Delivers**:
 
 - LSP test integration (CodeLens, run test, status indicators)
 - Consolidated test framework (single source of truth in `/examples`)
@@ -1163,9 +1163,9 @@ fn move_player(direction: Vector2) {
 - Autocomplete and navigation
 - Hover tooltips and refactoring tools
 
-**Decision**: We chose Option A for all three decisions, accelerating LSP foundation into v0.0.6 to establish compiler infrastructure early.
+**Decision**: We chose Option A for all three decisions, accelerating LSP foundation into v0.0.7 to establish compiler infrastructure early.
 
 **See Also**:
 
-- `docs/planning/v0.0.6/CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md` - Detailed implementation guide
+- `docs/planning/v0.0.7/CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md` - Detailed implementation guide
 - `docs/planning/ROADMAP_MASTER.md` - Version roadmap and consistency checklist

--- a/docs/planning/v0.0.7/README.md
+++ b/docs/planning/v0.0.7/README.md
@@ -1,0 +1,814 @@
+# FerrisScript v0.0.7: LSP Foundation + Test Framework
+
+> **Moved from the v0.0.6 slot on 2026-07-21** — pushed behind language
+> features (new v0.0.6: arrays/for/match/string interpolation) after a
+> roadmap review found no current audience for LSP tooling and flagged
+> the compiler-prerequisites refactor below as the highest-risk work on
+> the roadmap. Content below is otherwise unchanged from the original
+> planning. See `ROADMAP_MASTER.md`'s v0.0.7 section for the full rationale.
+
+**Timeline**: unknown — re-baseline against v0.0.6's actual pace before starting (historical estimate "6-7 weeks" already doubled once pre-implementation; treat as unreliable, see note above)  
+**Status**: Planning Complete, execution deferred behind v0.0.6  
+**Start Date**: TBD (after v0.0.6 ships)  
+**Target Completion**: TBD
+
+---
+
+## 📋 Table of Contents
+
+- [Problem Statement](#-problem-statement)
+- [Solution Overview](#-solution-overview)
+- [Key Deliverables](#-key-deliverables)
+- [Acceptance Criteria](#-acceptance-criteria)
+- [Phase Breakdown](#-phase-breakdown)
+- [Work Delegation Strategy](#-work-delegation-strategy)
+- [Dependencies & Critical Path](#-dependencies--critical-path)
+- [Risk Management](#️-risk-management)
+- [Success Metrics](#-success-metrics)
+
+---
+
+## 🎯 Problem Statement
+
+### Current Pain Points
+
+1. **No Real-Time Feedback**: Developers must compile manually to see type errors
+   - Write code → Save → Run `cargo build` → Read terminal output → Fix
+   - Feedback loop takes 30+ seconds per iteration
+   - Type safety feels like a burden, not a benefit
+
+2. **Fragmented Test Infrastructure**: Tests duplicated between `/examples` and `/godot_test/scripts`
+   - Manual test registration required
+   - No automated test discovery
+   - Platform-specific failures (Windows symlinks)
+   - CI doesn't catch all issues
+
+3. **Slow Compilation for LSP**: Full recompilation on every keystroke
+   - 150ms+ per edit is too slow for good editor experience
+   - No caching or incremental compilation
+   - LSP would feel sluggish and unresponsive
+
+4. **Missing LSP Foundation**: Compiler lacks infrastructure for editor integration
+   - No source span tracking (can't map errors to exact locations)
+   - No symbol table (can't implement go-to-definition)
+   - No incremental compilation (can't respond fast enough)
+
+### Impact on Adoption
+
+- **Developer Experience**: Static types without LSP = "annoying compile errors"
+- **Competitive Position**: GDScript has better IDE support despite dynamic typing
+- **Testing Friction**: Hard to add new tests, easy to break existing ones
+- **Iteration Speed**: Slow feedback loops discourage experimentation
+
+---
+
+## 💡 Solution Overview
+
+### What We're Building
+
+**v0.0.7 transforms FerrisScript from "compile-time safety" to "real-time developer experience"**
+
+#### Three Pillars
+
+1. **Compiler Prerequisites** (Weeks 1-3)
+   - Source spans: Map every AST node to exact source location
+   - Symbol table: Track all variables, functions, types across files
+   - Incremental compilation: Cache ASTs, recompile only changed regions
+   - **Goal**: Foundation for fast, accurate LSP
+
+2. **Test Framework Consolidation** (Weeks 4-7)
+   - Single source of truth: All tests in `/examples` with metadata
+   - Automated discovery: No manual registration
+   - LSP integration: Run tests from editor with "Run Test" button
+   - CI automation: JSON output for automated parsing
+   - **Goal**: Zero-friction testing for contributors
+
+3. **LSP Test Integration** (Week 5)
+   - Custom LSP protocol: `ferrisscript/documentTests`, `ferrisscript/runTest`
+   - CodeLens provider: Visual "Run Test" buttons in editor
+   - Real-time status: ✅/❌/⏱️ indicators
+   - Test result cache: Fast status updates
+   - **Goal**: Validate LSP infrastructure with low-risk scope
+
+### Why This Order?
+
+1. **Compiler first**: LSP needs spans, symbol table, incremental compilation
+2. **Test framework second**: Provides structured test cases for LSP validation
+3. **LSP test integration third**: Proves LSP works end-to-end before full diagnostics
+4. **General LSP later** (v0.1.0): Expand to all code once foundation is solid
+
+---
+
+## 🎁 Key Deliverables
+
+### Phase 0: Compiler Prerequisites (Weeks 1-3)
+
+| Deliverable | Description | Impact |
+|-------------|-------------|--------|
+| **Source Spans** | Every AST node tracks `(file, line, column, offset)` | LSP can show red squiggles at exact locations |
+| **Symbol Table** | Public API: `lookup(name) -> Symbol`, `all_symbols() -> Vec<Symbol>` | LSP can implement go-to-definition, autocomplete |
+| **Incremental Compiler** | `compile_file(uri, source)` with AST caching | <100ms compilation on typical edits |
+| **Dependency Graph** | Tracks which files import which, transitive invalidation | Cache invalidation works correctly |
+
+### Phase 1: Test Framework (Week 4)
+
+| Deliverable | Description | Impact |
+|-------------|-------------|--------|
+| **Test Harness Crate** | `crates/test_harness` with metadata parser | Discovers tests from `/examples` automatically |
+| **Rust Integration** | `tests/ferris_integration_tests.rs` | `cargo test` runs all FerrisScript tests |
+| **Test Filtering** | `FERRIS_TEST_FILTER=bounce cargo test` | Run specific tests during development |
+| **Cross-Platform** | Works on Windows/Linux/macOS | No more symlink failures |
+
+### Phase 2-2.5: LSP Foundation + Test Integration (Week 5)
+
+| Deliverable | Description | Impact |
+|-------------|-------------|--------|
+| **LSP Server** | `crates/lsp` with tower-lsp | Foundation for all LSP features |
+| **Document Manager** | Tracks open files, incremental updates | Handles `textDocument/didChange` efficiently |
+| **Custom Protocol** | `ferrisscript/documentTests`, `ferrisscript/runTest` | Editor can discover and run tests |
+| **CodeLens Provider** | VS Code extension shows "Run Test" buttons | Visual test execution from editor |
+
+### Phase 3-4: Godot Test Runner + Diagnostics (Week 6)
+
+| Deliverable | Description | Impact |
+|-------------|-------------|--------|
+| **Test Runner GDScript** | `godot_test/test_runner.gd` | Headless Godot test execution |
+| **Assertion Validation** | `get_variable()`, `get_emitted_signals()` | Tests actually validate behavior |
+| **Timeout Mechanism** | Configurable timeouts (default 10s) | Prevents hanging tests |
+| **Real-Time Diagnostics** | LSP publishes errors as you type | Red squiggles for type errors |
+
+### Phase 5: CI Integration (Week 7)
+
+| Deliverable | Description | Impact |
+|-------------|-------------|--------|
+| **GitHub Actions** | Updated workflow with new test harness | Automated testing on every PR |
+| **JSON Output** | `test_runner.gd --json` mode | CI can parse results |
+| **Test Migration** | All tests moved to `/examples` | Single source of truth |
+
+---
+
+## ✅ Acceptance Criteria
+
+### Must Have (Blocking Release)
+
+- [ ] **All AST nodes have source spans**
+  - Parser tracks spans from tokens
+  - All tests updated with span assertions
+  - Error messages show exact locations
+
+- [ ] **Symbol table built during type checking**
+  - `SymbolTable` API: `lookup()`, `all_symbols()`, `symbols_in_scope()`
+  - Integration tests verify symbol resolution
+  - Public API documented
+
+- [ ] **Incremental compilation working**
+  - Cache hit rate >80% for typical edits
+  - <100ms latency for cache hits
+  - 5-10x speedup vs full recompilation
+
+- [ ] **Test framework consolidated**
+  - Zero `.ferris` files in `/godot_test/scripts`
+  - All tests in `/examples` with metadata
+  - `cargo test` discovers and runs all tests
+
+- [ ] **LSP test integration working**
+  - CodeLens shows "Run Test" button
+  - Clicking runs test and shows result (✅/❌)
+  - Test status persists in cache
+
+- [ ] **Cross-platform compatibility**
+  - Tests pass on Windows, Linux, macOS
+  - No platform-specific workarounds
+  - CI validates all platforms
+
+### Should Have (Nice to Have)
+
+- [ ] **Performance optimizations**
+  - Cache eviction policy (LRU)
+  - Disk cache for persistence
+  - Metrics dashboard
+
+- [ ] **Enhanced test metadata**
+  - Regex patterns for assertions
+  - Multiple timeout values
+  - Test categories/tags
+
+- [ ] **Better error messages**
+  - Span-based error highlighting
+  - Suggested fixes
+  - Error code links to docs
+
+### Won't Have (Deferred to v0.1.0)
+
+- ❌ **Hover tooltips** (needs Phase 0.2, but UI deferred)
+- ❌ **Autocomplete** (needs Phase 0.2, but UI deferred)
+- ❌ **Go-to-definition** (needs Phase 0.1, but UI deferred)
+- ❌ **Find references** (needs Phase 0.2, but UI deferred)
+
+---
+
+## 📦 Phase Breakdown
+
+### Phase 0: Compiler Prerequisites (Weeks 1-3) 🔴 CRITICAL PATH
+
+**Why First**: LSP fundamentally requires these features. Cannot proceed without them.
+
+#### Week 1: Source Spans + Inspector Fix
+
+**Goal**: Every AST node knows where it came from in the source code + fix Inspector property refresh bug
+
+**Tasks**:
+
+1. Define `Span` and `Position` structs (`crates/compiler/src/span.rs`)
+2. Add `span` field to all AST nodes (`crates/compiler/src/ast.rs`)
+3. Update parser to track spans from tokens
+4. Update all tests with span assertions (543 compiler tests)
+5. **🆕 Fix Inspector property refresh on compilation errors** (Quick win, 1-2 hours)
+
+**Acceptance Criteria**:
+
+- [x] `Span::new(start, end)` and `Span::merge(other)` work
+- [x] Every `Expr`, `Stmt`, `Type` has a `span()` method
+- [x] Parser creates spans from token positions
+- [x] Error messages include `Span` information
+- [x] All 568 compiler tests pass with spans (31 new span unit tests + 5 integration tests)
+- [x] **🆕 Inspector clears properties on compilation failure** (PR #60, shipped in v0.0.5)
+- [x] **🆕 Switching scripts after type error updates Inspector correctly** (PR #60, verified headlessly in v0.0.5 — see `INSPECTOR_PROPERTY_FIX.md`)
+
+**Complexity**: 🔴 HIGH (touches entire AST, all tests)  
+**Delegation**: ❌ **User-Interactive** (requires careful review of each AST node)
+
+**Quick Win**: Inspector fix can run in parallel as background agent task  
+**📄 Inspector Fix Details**: See [INSPECTOR_PROPERTY_FIX.md](INSPECTOR_PROPERTY_FIX.md)
+
+**✅ Completed (PR #TBD)**: Tasks 1-4 complete. Created `span.rs` module with Position/Span structs, updated AST/parser/type_checker, all tests passing.
+
+**⚠️ Implementation Notes**:
+
+- **Byte offset tracking**: Currently using placeholder `0` values. Lexer doesn't track byte positions yet. Deferred to future enhancement (can calculate from line/column if needed, but adds overhead).
+- **Point spans**: Most spans are zero-length (start == end) because `span_from()` helper exists but isn't called yet. Multi-token span tracking deferred to Week 2 parser enhancements.
+- **Backward compatibility**: Re-exported `Span` from `ast` module to avoid breaking runtime crate. All existing `ast::Span` references still work.
+
+---
+
+#### Week 2: Symbol Table
+
+**Goal**: Extract symbol information for LSP (variables, functions, types)
+
+**Tasks**:
+
+1. Define `SymbolTable`, `Symbol`, `Scope` structs (`crates/compiler/src/symbol_table.rs`)
+2. Refactor `TypeChecker` to build `SymbolTable` during type checking
+3. Update `compile()` to return `(Type, SymbolTable)`
+4. Add integration tests for symbol resolution
+
+**Acceptance Criteria**:
+
+- [ ] `SymbolTable::lookup(name)` returns `Option<&Symbol>`
+- [ ] `SymbolTable::all_symbols()` returns all symbols
+- [ ] `SymbolTable::symbols_in_scope(id)` walks scope chain
+- [ ] `TypeChecker` inserts symbols for variables, functions, parameters
+- [ ] Integration tests verify symbol table correctness
+
+**Complexity**: 🟡 MEDIUM (refactoring existing type checker)  
+**Delegation**: ⚠️ **User-Guided** (needs review of type checker logic)
+
+---
+
+#### Week 3: Incremental Compilation
+
+**Goal**: Cache ASTs and recompile only changed regions
+
+**Tasks**:
+
+1. Implement `IncrementalCompiler` with AST caching (`crates/compiler/src/incremental.rs`)
+2. Add source hash-based cache invalidation
+3. Create `DependencyGraph` for transitive invalidation
+4. Performance benchmarks (cache hit rate, latency)
+
+**Acceptance Criteria**:
+
+- [ ] `IncrementalCompiler::compile_file(uri, source)` uses cache
+- [ ] Cache hit returns result in <50ms (target: <100ms acceptable)
+- [ ] Cache miss does full compilation and caches result
+- [ ] `DependencyGraph` invalidates dependent files
+- [ ] Benchmarks show 5-10x speedup for cache hits
+- [ ] Cache hit rate >80% for typical editing sessions
+
+**Complexity**: 🟡 MEDIUM (new module, integration with compiler)  
+**Delegation**: ✅ **Background Agent** (well-defined spec, testable in isolation)
+
+---
+
+### Phase 1: Test Framework Foundation (Week 4)
+
+**Why Now**: Provides test infrastructure for validating LSP integration
+
+#### Tasks
+
+1. **Create Test Harness Crate** (2 days)
+   - `crates/test_harness/Cargo.toml`
+   - Metadata parser: `parse_test_metadata(source) -> TestMetadata`
+   - Test discovery: `discover_tests(examples_dir) -> Vec<TestFile>`
+   - Error handling with `thiserror`
+
+2. **Rust Test Integration** (2 days)
+   - `tests/ferris_integration_tests.rs`
+   - Test filtering: `FERRIS_TEST_FILTER=bounce cargo test`
+   - Parallel execution with `rayon`
+   - Negative testing support
+
+3. **Cross-Platform Validation** (1 day)
+   - Test on Windows (absolute paths, no symlinks)
+   - Test on Linux (standard paths)
+   - Test on macOS (if available)
+
+**Acceptance Criteria**:
+
+- [ ] `cargo test` discovers all `.ferris` files in `/examples`
+- [ ] Metadata parsing handles all fields: `TEST:`, `CATEGORY:`, `EXPECT:`, `ASSERT:`, `TIMEOUT:`
+- [ ] Test filtering works: `FERRIS_TEST_FILTER=bounce cargo test` runs only bounce test
+- [ ] Cross-platform: Tests pass on Windows, Linux, macOS
+- [ ] All tests have clear error messages for malformed metadata
+
+**Complexity**: 🟢 LOW (new crate, clear spec)  
+**Delegation**: ✅ **Background Agent** (unambiguous requirements, well-tested)
+
+---
+
+### Phase 2: LSP Server Foundation (Week 5a - Days 1-3)
+
+**Why Now**: Needs Phase 0 (compiler prerequisites) complete
+
+#### Tasks
+
+1. **Create LSP Crate** (1 day)
+   - `crates/lsp/Cargo.toml` with `tower-lsp` dependency
+   - Basic server struct: `FerrisScriptServer`
+   - Initialize/shutdown handlers
+
+2. **Document Manager** (1 day)
+   - Track open documents: `HashMap<Url, Document>`
+   - Apply incremental changes: `did_change` handler
+   - Integrate with `IncrementalCompiler` from Phase 0.3
+
+3. **Text Synchronization** (1 day)
+   - Handle `textDocument/didOpen`
+   - Handle `textDocument/didChange` (incremental)
+   - Handle `textDocument/didClose`
+
+**Acceptance Criteria**:
+
+- [ ] LSP server starts and responds to `initialize` request
+- [ ] Document manager tracks open files
+- [ ] Incremental changes apply correctly (no corruption)
+- [ ] `IncrementalCompiler` recompiles on each change
+- [ ] Server handles multiple documents simultaneously
+
+**Complexity**: 🟡 MEDIUM (new LSP infrastructure)  
+**Delegation**: ⚠️ **User-Guided** (LSP protocol requires careful implementation)
+
+---
+
+### Phase 2.5: LSP Test Integration (Week 5b - Days 4-5)
+
+**Why Now**: Validates LSP works before full diagnostics (lower risk)
+
+#### Tasks
+
+1. **Custom LSP Protocol** (1 day)
+   - Define `ferrisscript/documentTests` request/response
+   - Define `ferrisscript/runTest` request/response
+   - Implement handlers in LSP server
+
+2. **Test Discovery API** (1 day)
+   - Use `test_harness` crate from Phase 1
+   - Parse test metadata from open documents
+   - Return test ranges (line numbers)
+
+3. **VS Code Extension** (1 day)
+   - `testProvider.ts` with CodeLens provider
+   - "Run Test" command
+   - Test result UI (✅/❌/⏱️)
+
+**Acceptance Criteria**:
+
+- [ ] Opening `.ferris` file shows "Run Test" button above test
+- [ ] Clicking button runs test via LSP
+- [ ] Test result appears in editor (✅ pass, ❌ fail)
+- [ ] Test status persists in cache (doesn't re-run on every edit)
+- [ ] Multiple tests in same file all work
+
+**Complexity**: 🟡 MEDIUM (custom LSP protocol, VS Code extension)  
+**Delegation**: ⚠️ **User-Guided** (integration between LSP server and VS Code)
+
+---
+
+### Phase 3: Real-Time Diagnostics (Week 6a - Days 1-3)
+
+**Why Now**: Validates incremental compilation works with LSP
+
+#### Tasks
+
+1. **Diagnostic Publishing** (1 day)
+   - Convert compile errors to LSP `Diagnostic` format
+   - Use `Span` from Phase 0.1 for accurate ranges
+   - Publish on every `textDocument/didChange`
+
+2. **Error Recovery** (1 day)
+   - Parser continues on errors (don't stop at first error)
+   - Type checker handles incomplete ASTs
+   - Show partial diagnostics even with syntax errors
+
+3. **Performance Validation** (1 day)
+   - Benchmark latency: target <100ms for typical edits
+   - Verify cache hit rate >80%
+   - Profile slow paths
+
+**Acceptance Criteria**:
+
+- [ ] Red squiggles appear as you type (not just on save)
+- [ ] Error messages accurate to exact location (uses spans)
+- [ ] Latency <100ms for cache hits (typical single-line edit)
+- [ ] Multiple errors shown simultaneously
+- [ ] Parser doesn't crash on incomplete code
+
+**Complexity**: 🟡 MEDIUM (error recovery is tricky)  
+**Delegation**: ⚠️ **User-Guided** (performance tuning requires iteration)
+
+---
+
+### Phase 4: Godot Test Runner (Week 6b - Days 4-5)
+
+**Why Now**: Can run in parallel with Phase 3 (different codebase)
+
+#### Tasks
+
+1. **Test Runner Script** (1 day)
+   - `godot_test/test_runner.gd`
+   - Discover tests via `FileAccess.open()` (no symlinks)
+   - Load and run FerrisScript via `FerrisScriptRunner`
+   - JSON output mode
+
+2. **Assertion Validation** (1 day)
+   - Add `get_variable(name)` to `FerrisScriptRunner`
+   - Add `get_emitted_signals()` to `FerrisScriptRunner`
+   - Parse `ASSERT:` metadata and validate
+   - Timeout mechanism (default 10s)
+
+**Acceptance Criteria**:
+
+- [ ] `godot --headless --script test_runner.gd` runs all tests
+- [ ] Tests timeout after 10s (configurable via `TIMEOUT:` metadata)
+- [ ] Assertions validate actual runtime behavior (not just "compiles")
+- [ ] JSON output parses correctly in CI
+- [ ] Works on Windows (no symlink issues)
+
+**Complexity**: 🟢 LOW (GDScript, clear spec)  
+**Delegation**: ✅ **Background Agent** (well-defined, testable in Godot)
+
+---
+
+### Phase 5: CI Integration & Migration (Week 7)
+
+**Why Now**: Final integration, migration, polish
+
+#### Tasks
+
+1. **GitHub Actions Workflow** (1 day)
+   - Update `.github/workflows/test.yml`
+   - Run `cargo test` (Phase 1 harness)
+   - Run `godot --headless` (Phase 4 runner)
+   - Parse JSON results
+
+2. **Test Migration** (2 days)
+   - Move all `.ferris` files from `/godot_test/scripts` to `/examples`
+   - Add metadata to each test
+   - Update documentation
+
+3. **Cleanup** (1 day)
+   - Remove old test infrastructure
+   - Update README
+   - Create migration guide for contributors
+
+4. **Final Validation** (1 day)
+   - Run full test suite on CI
+   - Verify all platforms pass
+   - Check performance metrics
+
+**Acceptance Criteria**:
+
+- [ ] CI runs on every PR and passes
+- [ ] No `.ferris` files remain in `/godot_test/scripts`
+- [ ] All tests have metadata headers
+- [ ] Documentation updated (README, CONTRIBUTING)
+- [ ] Migration guide written
+
+**Complexity**: 🟢 LOW (mostly migration, documentation)  
+**Delegation**: ✅ **Background Agent** (bulk file operations, well-defined)
+
+---
+
+## 🤖 Work Delegation Strategy
+
+### Background Agent Tasks (Can Run Unattended)
+
+These tasks have:
+
+- ✅ Clear, unambiguous requirements
+- ✅ Well-defined acceptance criteria
+- ✅ No complex design decisions
+- ✅ Easy to verify automatically (tests)
+
+| Phase | Task | Rationale |
+|-------|------|-----------|
+| **0.3** | Incremental Compilation | Well-specified caching logic, testable in isolation |
+| **1** | Test Harness Crate | New crate, clear spec, comprehensive tests |
+| **4** | Godot Test Runner | GDScript implementation, clear inputs/outputs |
+| **5** | Test Migration | Bulk file operations, metadata addition |
+| **5** | CI Integration | GitHub Actions YAML, JSON parsing |
+
+**Estimated Background Work**: ~2-3 weeks of the 6-7 week timeline
+
+---
+
+### User-Guided Tasks (Need Iteration & Feedback)
+
+These tasks have:
+
+- ⚠️ Complex design decisions
+- ⚠️ Integration with existing code
+- ⚠️ Performance tuning required
+- ⚠️ Multiple valid approaches
+
+| Phase | Task | Why User-Guided |
+|-------|------|-----------------|
+| **0.1** | Source Spans in AST | Touches 543 tests, every AST node, needs careful review |
+| **0.2** | Symbol Table Extraction | Refactors type checker, complex scope handling |
+| **2** | LSP Server Foundation | LSP protocol requires careful implementation |
+| **2.5** | LSP Test Integration | Custom protocol, VS Code extension integration |
+| **3** | Real-Time Diagnostics | Error recovery is tricky, performance tuning |
+
+**Estimated User-Guided Work**: ~3-4 weeks of the 6-7 week timeline
+
+---
+
+### Parallelization Opportunities
+
+| Primary Track | Secondary Track (Background Agent) | Week |
+|---------------|-----------------------------------|------|
+| Phase 0.1: Source Spans | - | 1 |
+| Phase 0.2: Symbol Table | - | 2 |
+| Phase 0.3: Incremental Compilation ⚠️ | Can be background if spec clear | 3 |
+| Phase 1: Test Harness (user review) | Phase 1: Tests/docs (agent writes) | 4 |
+| Phase 2: LSP Server (user guided) | Phase 4: Godot Runner (agent writes) | 5 |
+| Phase 2.5 + 3: LSP Test Integration | - | 6 |
+| Phase 5: Final validation | Phase 5: Migration (agent executes) | 7 |
+
+**Key Insight**: Weeks 4-6 have the most parallelization potential. User works on LSP while agent handles Godot test runner.
+
+---
+
+## 🔗 Dependencies & Critical Path
+
+### Critical Path (Must Complete in Order)
+
+```
+Phase 0.1 (Spans) 
+    ↓
+Phase 0.2 (Symbol Table) 
+    ↓
+Phase 0.3 (Incremental Compilation)
+    ↓
+Phase 2 (LSP Server Foundation)
+    ↓
+Phase 2.5 (LSP Test Integration)
+    ↓
+Phase 3 (Real-Time Diagnostics)
+```
+
+**Timeline**: 6 weeks (Weeks 1-6)
+
+**Blocker**: Cannot start Phase 2 until Phase 0 complete (needs spans, symbol table, incremental compiler)
+
+---
+
+### Parallel Paths (Can Run Simultaneously)
+
+```
+Phase 1 (Test Harness) ─┐
+                        ├─→ Phase 2.5 (LSP Test Integration)
+Phase 4 (Godot Runner) ─┘
+
+Phase 5 (CI Integration) ← All above complete
+```
+
+**Optimization**:
+
+- Phase 1 (Week 4) can run while finishing Phase 0 if Phase 0 is ahead of schedule
+- Phase 4 (Week 6) can run in parallel with Phase 3 (different codebase)
+- Phase 5 (Week 7) waits for everything
+
+---
+
+## ⚠️ Risk Management
+
+### High-Risk Items (Require Mitigation)
+
+#### Risk 1: Compiler Refactoring Breaks Tests 🔴 HIGH
+
+**Probability**: Very High  
+**Impact**: All 543 compiler tests may fail after adding spans
+
+**Mitigation**:
+
+- Add spans incrementally (one AST node type at a time)
+- Use default/dummy spans for unmodified nodes during transition
+- Run full test suite after each AST change
+- Create migration script to bulk-update test assertions
+- **Timeline Buffer**: 1 week contingency built into Phase 0
+
+**Decision Point**: End of Week 1 - if span migration is slower than expected, consider temporary dummy spans
+
+---
+
+#### Risk 2: Incremental Compilation Cache Bugs 🔴 HIGH
+
+**Probability**: Medium  
+**Impact**: LSP shows stale errors, incorrect completions
+
+**Mitigation**:
+
+- Extensive unit tests for cache invalidation (test each scenario)
+- Add cache validation mode (compare cached vs fresh compilation)
+- Implement "force full recompilation" command in LSP
+- Monitor cache hit rate in production
+- **Fallback**: Disable caching if bugs persist (graceful degradation)
+
+**Decision Point**: End of Week 3 - verify cache correctness before proceeding to LSP
+
+---
+
+#### Risk 3: Timeline Overrun (7 weeks → 9+ weeks) 🟡 MEDIUM
+
+**Probability**: Medium  
+**Impact**: Delayed v0.0.7 release
+
+**Mitigation**:
+
+- Phase 0 has highest risk (3 weeks of compiler changes)
+- Weekly check-ins to assess timeline
+- De-scope features if falling behind (see Priority Plan below)
+- **Decision Point**: End of Week 3 (reassess after Phase 0)
+
+**De-Scoping Priority**:
+
+**Priority 1 (Must Keep)**:
+
+- Source spans in AST
+- Symbol table extraction
+- Basic LSP diagnostics
+- Test framework foundation
+
+**Priority 2 (Defer to v0.1.0 if behind)**:
+
+- Incremental compilation (fallback: always recompile)
+- LSP test integration (ship test framework standalone)
+
+**Priority 3 (Defer to v0.1.0)**:
+
+- Advanced caching strategies
+- Dependency graph optimizations
+
+---
+
+### Medium-Risk Items (Monitor Closely)
+
+#### Risk 4: LSP Protocol Complexity 🟡 MEDIUM
+
+**Mitigation**: Start with simple test-specific LSP (Phase 2.5) before full diagnostics
+
+#### Risk 5: Cross-Platform Test Failures 🟡 MEDIUM
+
+**Mitigation**: Test on all platforms early (Phase 1, Week 4)
+
+#### Risk 6: Performance Regression 🟡 MEDIUM
+
+**Mitigation**: Benchmark cache hit rate, establish performance baselines
+
+---
+
+## 📊 Success Metrics
+
+### Performance Metrics
+
+| Metric | Target | Acceptable | Measurement |
+|--------|--------|------------|-------------|
+| **Cache Hit Rate** | >95% | >80% | Track in `IncrementalCompiler::metrics()` |
+| **Cache Hit Latency** | <50ms | <100ms | Benchmark on typical edits |
+| **Cache Miss Latency** | <200ms | <500ms | Full recompilation time |
+| **Speedup vs Full Recompile** | 10x | 5x | Compare cache hit vs miss |
+| **LSP Response Time** | <100ms | <200ms | `textDocument/didChange` → diagnostics published |
+
+---
+
+### Quality Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| **Test Coverage** | >80% | Lines covered by `cargo test` |
+| **Cross-Platform** | 100% pass | Tests pass on Windows, Linux, macOS |
+| **Zero Regressions** | 0 | All 843 existing tests still pass |
+| **Documentation** | 100% | All public APIs documented |
+
+---
+
+### Adoption Metrics (Post-Release)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| **LSP Usage** | >50% of contributors | VS Code extension installs |
+| **Test Additions** | +10% tests in 2 weeks | Track new `.ferris` files in `/examples` |
+| **Issue Reports** | <5 critical bugs | GitHub issues labeled `v0.0.7` |
+| **Feedback Sentiment** | >80% positive | Survey or Discord reactions |
+
+---
+
+## 📚 Related Documents
+
+- **[CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md](./CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md)**: Detailed implementation guide with code examples
+- **[LSP_ARCHITECTURE_SUPPORT.md](./LSP_ARCHITECTURE_SUPPORT.md)**: LSP architecture, rationale, and incremental compilation details
+- **[ROADMAP_MASTER.md](../ROADMAP_MASTER.md)**: High-level version roadmap and consistency checklist
+
+---
+
+## 🚀 Getting Started
+
+### For Contributors
+
+1. **Read this README** to understand the big picture
+2. **Review Phase 0** (Compiler Prerequisites) - this is the critical path
+3. **Check [CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md](./CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md)** for detailed implementation
+4. **Start with Phase 0.1** (Source Spans) - Week 1
+
+### For Project Leads
+
+1. **Review delegation strategy** (Background Agent vs User-Guided)
+2. **Set up weekly check-ins** (especially end of Week 3 decision point)
+3. **Monitor risk items** (compiler refactoring, cache bugs, timeline)
+4. **Prepare de-scoping plan** if timeline slips
+
+### For Background Agents
+
+**Week 3-4**: Incremental Compilation (Phase 0.3) + Test Harness (Phase 1)  
+**Week 5-6**: Godot Test Runner (Phase 4)  
+**Week 7**: Test Migration + CI Integration (Phase 5)
+
+---
+
+## 🔗 Related Documents
+
+### Planning Documents
+
+- **[CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md](CONSOLIDATED_TEST_FRAMEWORK_IMPLEMENTATION.md)**: Detailed technical implementation guide with code examples
+- **[LSP_ARCHITECTURE_SUPPORT.md](LSP_ARCHITECTURE_SUPPORT.md)**: LSP architecture, incremental compilation design, decision log
+- **[ROADMAP_MASTER.md](../ROADMAP_MASTER.md)**: High-level version roadmap and consistency checklist
+
+### Task Documents
+
+- **[INSPECTOR_PROPERTY_FIX.md](INSPECTOR_PROPERTY_FIX.md)**: 🆕 Quick win bug fix (Phase 0.1.5) - Inspector property refresh on compilation error
+
+### Reference Documents
+
+- **[TROUBLESHOOTING.md](../../TROUBLESHOOTING.md)**: Known issues and workarounds
+- **[DEVELOPMENT.md](../../DEVELOPMENT.md)**: Development workflow and contribution guide
+- **[ARCHITECTURE.md](../../ARCHITECTURE.md)**: System architecture overview
+
+---
+
+## ✅ Current Status
+
+- [x] **Planning Complete** (October 13, 2025)
+  - [x] Option A decisions documented
+  - [x] All three documents aligned (CONSOLIDATED, LSP, ROADMAP)
+  - [x] README.md created with phase breakdown
+  - [x] Delegation strategy defined
+  - [x] Inspector fix task document created (INSPECTOR_PROPERTY_FIX.md)
+
+- [ ] **Phase 0.1: Source Spans** (Week 1)
+  - [ ] Define `Span` and `Position` structs
+  - [ ] Add spans to all AST nodes
+  - [ ] Update parser to track spans
+  - [ ] Update all 543 compiler tests
+
+- [ ] **Phase 0.2: Symbol Table** (Week 2)
+- [ ] **Phase 0.3: Incremental Compilation** (Week 3)
+- [ ] **Phase 1: Test Framework** (Week 4)
+- [ ] **Phase 2-2.5: LSP Foundation + Test Integration** (Week 5)
+- [ ] **Phase 3-4: Diagnostics + Godot Runner** (Week 6)
+- [ ] **Phase 5: CI Integration & Migration** (Week 7)
+
+---
+
+**Last Updated**: October 13, 2025  
+**Next Review**: End of Week 3 (Decision Point)

--- a/docs/planning/v0.0.7/RUSTDOC_IMPLEMENTATION_PLAN.md
+++ b/docs/planning/v0.0.7/RUSTDOC_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Rustdoc Implementation Plan for FerrisScript
 
-**Version**: v0.0.6 (or later)  
+**Version**: v0.0.7 (or later)  
 **Created**: October 13, 2025  
 **Status**: Planning  
 **Effort Estimate**: 2-3 weeks (Medium complexity)
@@ -676,7 +676,7 @@ pub fn my_method(&self, param1: Type1, param2: Type2) -> Result<Output, Error> {
 
 ## 🚀 Future Enhancements
 
-### Phase 5: Rustdoc JSON Export (Post-v0.0.6)
+### Phase 5: Rustdoc JSON Export (Post-v0.0.7)
 
 **Goal**: Enable AI-assisted development via Rustdoc JSON
 
@@ -870,4 +870,4 @@ fn extract_docs(json_path: &str) -> Result<Vec<DocItem>, Error> {
 ---
 
 **Status**: Ready for implementation  
-**Next Steps**: Assign to v0.0.6 milestone and begin Phase 1
+**Next Steps**: Assign to v0.0.7 milestone and begin Phase 1


### PR DESCRIPTION
## Summary

A 2026-07-21 multi-agent review (documentation audit, roadmap strategy audit, technical-debt scan) recommended reversing the plan: **v0.0.6 should ship language features (arrays/for/match/string interpolation) before v0.0.7's LSP work**, not after.

**Why**: FerrisScript cannot express a loop over a collection today. The LSP compiler-prerequisites refactor is flagged "Very High" risk in its own docs (touches all 543+ compiler tests) and would serve zero known external users. Meanwhile the language-features work that actually unblocks real usage had no scoping doc at all — versus LSP's ~7,000 lines of planning across 5 documents.

## Changes

- Swap v0.0.6 ↔ v0.0.7 content in `ROADMAP_MASTER.md`; `git mv docs/planning/v0.0.6/ → v0.0.7/` (LSP plan, content unchanged, cross-references fixed)
- **New `docs/planning/v0.0.6/README.md`**: a real scoping doc for language features — syntax decisions with rationale, mutation semantics, reserved error-code ranges (E900-E969), suggested implementation order, test plan, explicit out-of-scope list
- Mark v0.0.5 complete throughout (a couple of spots still said "in progress" from before the tag/release happened)
- New **"Known Gaps (Not Yet Planned)"** section: no community/adoption plan, no "real playable game" checkpoint, no pre-1.0 compatibility policy, no estimate-recalibration trigger — flagged, not solved, since these need the maintainer's judgment
- Mark the Positioning table's determinism/lockstep-multiplayer/1000-agent claims as aspirational rather than present-tense (none of it exists today)
- Superseded banners on the now-outdated "Parallelization Strategy" timeline and "Editor Experience First" strategic priority (both assumed LSP-first)
- Fix `VISION.md`/`VISION_USE_CASE_ANALYSIS.md` version labels (one increment behind after this morning's v0.0.5→v0.0.6 cascade rename)
- Replace the stale "Next Actions" section (still said "This Week: execute v0.0.4 Phase 2") with the actual current state

## Test plan

- `npm run docs:lint` passes
- Docs-only change; no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)